### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import logo from "@/app/img/logo.svg";
 import { useAuth } from "../context/AuthContext";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -35,6 +36,7 @@ export default function Header() {
 
                     {/* Desktop Links */}
                     <div className="hidden md:flex items-center space-x-8 font-medium">
+                        <ThemeToggle />
                         {loggedIn ? (
                             <button
                                 onClick={logout}
@@ -113,6 +115,9 @@ export default function Header() {
                         {/* Drawer Links */}
                         <nav className="mt-8 px-4">
                             <ul className="space-y-6">
+                                <li>
+                                    <ThemeToggle />
+                                </li>
                                 {loggedIn ? (
                                     <li>
                                         <button

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+import { useTheme } from "../context/ThemeContext";
+
+export default function ThemeToggle() {
+    const { theme, toggleTheme } = useTheme();
+    return (
+        <button
+            onClick={toggleTheme}
+            aria-label="Toggle Theme"
+            className="p-2 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+        >
+            {theme === "dark" ? (
+                <SunIcon className="w-6 h-6 text-yellow-400" />
+            ) : (
+                <MoonIcon className="w-6 h-6 text-gray-800" />
+            )}
+        </button>
+    );
+}

--- a/src/app/context/ThemeContext.tsx
+++ b/src/app/context/ThemeContext.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeState {
+    theme: Theme;
+    toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeState>({
+    theme: "light",
+    toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+    const [theme, setTheme] = useState<Theme>("light");
+
+    useEffect(() => {
+        const stored = localStorage.getItem("theme");
+        if (stored === "dark" || stored === "light") {
+            setTheme(stored);
+            document.documentElement.classList.toggle("dark", stored === "dark");
+        }
+    }, []);
+
+    const toggleTheme = () => {
+        const next = theme === "light" ? "dark" : "light";
+        setTheme(next);
+        localStorage.setItem("theme", next);
+        document.documentElement.classList.toggle("dark", next === "dark");
+    };
+
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme() {
+    return useContext(ThemeContext);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,15 @@ body {
     padding: 0;
     margin: 0;
     font-family: "Poppins", sans-serif;
-    background-color: inherit;
+}
+
+html {
+    background-color: #ffffff;
+}
+
+html.dark {
+    background-color: #080808;
+    color-scheme: dark;
 }
 
 /* Minimal fade-in-up animation for sidebars */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import { Inter } from "next/font/google";
 import { AuthProvider } from "./context/AuthContext";
 import { CartProvider } from "./context/CartContext";
+import { ThemeProvider } from "./context/ThemeContext";
 import Header from "./components/Header";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -68,8 +69,9 @@ export default function RootLayout({
     return (
         <html lang="mn">
         <body
-            className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900`}
+            className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900 dark:bg-dark dark:text-white`}
         >
+        <ThemeProvider>
         <CartProvider>
         <AuthProvider>
             <div className="max-w-7xl w-full mx-auto md:px-6">
@@ -399,6 +401,7 @@ export default function RootLayout({
             </footer>
         </AuthProvider>
         </CartProvider>
+        </ThemeProvider>
         </body>
         </html>
     );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 // tailwind.config.js
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/**/*.{js,ts,jsx,tsx}', // Adjust based on your project structure
     './public/**/*.html',


### PR DESCRIPTION
## Summary
- support `darkMode: 'class'` in Tailwind
- add `ThemeContext` and `ThemeToggle` component
- apply dark theme styles in layout and global CSS
- integrate theme toggle in header

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bbba80988328a2886c168d7c6690