### PR TITLE
Add scrolling effects to bottom nav and new post route

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
     HomeIcon,
@@ -12,12 +12,31 @@ import {
 
 const BottomNav: React.FC = () => {
     const router = useRouter();
+    const [scrolledDown, setScrolledDown] = useState(false);
 
-    // Get nav height on initial mount if needed
+    useEffect(() => {
+        let lastY = window.scrollY;
+        const onScroll = () => {
+            const currentY = window.scrollY;
+            if (currentY > lastY && currentY > 0) {
+                setScrolledDown(true);
+            } else if (currentY <= lastY || currentY === 0) {
+                setScrolledDown(false);
+            }
+            lastY = currentY;
+        };
+
+        window.addEventListener("scroll", onScroll);
+        return () => window.removeEventListener("scroll", onScroll);
+    }, []);
 
     return (
         <nav
-            className="fixed bottom-0 left-0 w-full bg-white dark:bg-black md:hidden"
+            className={`fixed bottom-0 left-0 w-full md:hidden transition-all ${
+                scrolledDown
+                    ? "bg-white/60 dark:bg-black/60 backdrop-blur-md"
+                    : "bg-white dark:bg-black"
+            }`}
         >
             <div
                 className="flex justify-around items-center py-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]"
@@ -40,10 +59,10 @@ const BottomNav: React.FC = () => {
                     <MagnifyingGlassIcon className="h-7 w-7" />
                 </button>
 
-                {/* COMPOSE / PROFILE */}
+                {/* NEW POST */}
                 <button
-                    onClick={() => router.push("/profile")}
-                    aria-label="Profile"
+                    onClick={() => router.push("/new-post")}
+                    aria-label="New Post"
                     className="p-1 text-black dark:text-white"
                 >
                     <PlusCircleIcon className="h-8 w-8" />

--- a/src/app/new-post/page.tsx
+++ b/src/app/new-post/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+import React, { useRef, useState } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
+
+const BASE_URL = "https://www.vone.mn";
+
+export default function NewPostPage() {
+    const router = useRouter();
+    const { user } = useAuth();
+    const [content, setContent] = useState("");
+    const [imageFile, setImageFile] = useState<File | null>(null);
+    const [error, setError] = useState("");
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const triggerFileInput = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files?.[0]) {
+            setImageFile(e.target.files[0]);
+        }
+    };
+
+    const createPost = async () => {
+        setError("");
+        if (!content.trim()) {
+            setError("Контентыг бөглөнө үү");
+            return;
+        }
+        if (!user?.accessToken) {
+            setError("Нэвтэрч ороогүй байна.");
+            return;
+        }
+        try {
+            const formData = new FormData();
+            formData.append("content", content);
+            if (imageFile) formData.append("image", imageFile);
+
+            await axios.post(`${BASE_URL}/api/posts`, formData, {
+                headers: {
+                    Authorization: `Bearer ${user.accessToken}`,
+                    "Content-Type": "multipart/form-data",
+                },
+            });
+
+            router.push("/");
+        } catch (err) {
+            console.error("Create post error:", err);
+            setError("Алдаа гарлаа");
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-100 dark:bg-black text-gray-900 dark:text-white p-4">
+            <div className="max-w-xl mx-auto space-y-4">
+                <h1 className="text-xl font-bold">Create Post</h1>
+                <input
+                    type="file"
+                    accept="image/*"
+                    ref={fileInputRef}
+                    onChange={handleFileChange}
+                    className="hidden"
+                />
+                <button
+                    onClick={triggerFileInput}
+                    className="p-2 border border-gray-200 dark:border-black rounded-full hover:bg-gray-100 dark:hover:bg-black"
+                >
+                    Upload Image
+                </button>
+                {imageFile && (
+                    <span className="block text-xs text-gray-700 truncate">
+                        {imageFile.name}
+                    </span>
+                )}
+                <textarea
+                    placeholder="What's on your mind?"
+                    className="w-full text-sm text-gray-900 dark:text-white border border-gray-200 dark:border-black rounded p-2 focus:outline-none"
+                    rows={3}
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                />
+                {error && <p className="text-red-500 text-xs">{error}</p>}
+                <button
+                    onClick={createPost}
+                    className="mt-3 bg-[#1D9BF0] text-white text-xs px-4 py-2 rounded hover:bg-[#1A8CD8]"
+                >
+                    Post
+                </button>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- fade and blur bottom navigation while scrolling down
- route the plus icon to a dedicated New Post page
- implement new post form at `/new-post` for quick posting

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684881b4c3288328bbb5ebbf5aea2d9e