### PR TITLE
Add admin delete user endpoint and subscription UI updates

### DIFF
--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const User = require("../models/User");
 const authenticateToken = require("../middleware/authMiddleware");
+const Post = require("../models/Post");
 const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
@@ -222,5 +223,21 @@ router.put(
         }
     }
 );
+
+// Delete user and their posts (admin only)
+router.delete("/:id", authenticateToken, async (req, res) => {
+    try {
+        if (req.user.username !== "Antaqor") {
+            return res.status(403).json({ error: "Forbidden" });
+        }
+        const userId = req.params.id;
+        await Post.deleteMany({ user: userId });
+        await User.findByIdAndDelete(userId);
+        res.json({ message: "User and posts deleted" });
+    } catch (err) {
+        console.error("Delete user error:", err);
+        res.status(500).json({ error: "Server error" });
+    }
+});
 
 module.exports = router;

--- a/src/app/dashboard/members/page.tsx
+++ b/src/app/dashboard/members/page.tsx
@@ -110,7 +110,7 @@ export default function MembersDashboard() {
               <th className="p-2">Expires</th>
               <th className="p-2">VNT</th>
               <th className="p-2">Transferred</th>
-              <th className="p-2"></th>
+              <th className="p-2">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -136,6 +136,7 @@ function MemberRow({
   const { user } = useAuth();
   const [vnt, setVnt] = useState(member.vntBalance ?? 0);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState("");
 
   const saveVnt = async () => {
@@ -160,6 +161,26 @@ function MemberRow({
       setError(err.message);
     } finally {
       setSaving(false);
+    }
+  };
+  const deleteUser = async () => {
+    if (!user?.accessToken) return;
+    if (!confirm("Delete this user?")) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`${BACKEND_URL}/users/${member._id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${user.accessToken}` },
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to delete");
+      }
+      window.location.reload();
+    } catch (err) {
+      alert((err as any).message);
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -192,12 +213,19 @@ function MemberRow({
         {error && <span className="text-red-400 ml-2">{error}</span>}
       </td>
       <td className="p-2">{member.hasTransferred ? "✅" : ""}</td>
-      <td className="p-2">
+      <td className="p-2 space-x-2">
         <button
           onClick={() => onExtend(member._id)}
           className="px-2 py-1 bg-blue-600 rounded text-white"
         >
           Extend 30d
+        </button>
+        <button
+          onClick={deleteUser}
+          disabled={deleting}
+          className="px-2 py-1 bg-red-600 rounded text-white"
+        >
+          {deleting ? "..." : "Delete"}
         </button>
       </td>
     </tr>

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import Link from "next/link";
 import { useAuth } from "../context/AuthContext";
 
 // ── Types ───────────────────────────────────────────────
@@ -15,6 +16,10 @@ export default function SubscriptionPage() {
   const [memberCount, setMemberCount] = useState(0);
   const [showPaymentInfo, setShowPaymentInfo] = useState(false);
   const [countdown, setCountdown] = useState(0);
+
+  const isPro =
+    user?.subscriptionExpiresAt &&
+    new Date(user.subscriptionExpiresAt) > new Date();
 
   const BASE_URL = "https://www.vone.mn";
   const price =
@@ -130,6 +135,22 @@ export default function SubscriptionPage() {
               Шилжүүлсэн
             </button>
           )}
+        </div>
+      )}
+
+      {(isPro || paid) && (
+        <div className="mt-10 space-y-4 text-center">
+          <p className="text-green-700 font-semibold">
+            Таны гишүүнчлэл идэвхтэй!
+          </p>
+          <div className="flex justify-center gap-4">
+            <Link href="/books" className="px-4 py-2 bg-blue-600 text-white rounded">
+              Data
+            </Link>
+            <Link href="/" className="px-4 py-2 bg-blue-600 text-white rounded">
+              Feed
+            </Link>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- allow admins to delete a user and all of their posts
- expose premium links on subscription page once a membership is active
- enable member management page to remove users

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f96a0b5c8328a7dc8054db209d38