### PR TITLE
Remove fallback QPay secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ bun dev
 1. `server/.env.example` файлыг `server/.env` болгон хуулж, `MONGODB_URI`-д өгөгдлийн сангийн холбоосоо бичнэ.
 2. API серверийг `npm run server` (эсвэл `npm run server-dev` автоматаар дахин ачаалуулах) командаар эхлүүлнэ.
 
+Дараах орчны хувьсагчуудыг `server/.env` файлд тохируулна:
+
+- `MONGODB_URI` – MongoDB-ийн холбоос
+- `PORT` – (сонголттой) серверийн порт
+- `UPLOAD_DIR` – файлууд хадгалагдах санд
+- `QPAY_CLIENT_ID` – QPay-ийн Client ID
+- `QPAY_CLIENT_SECRET` – QPay-ийн Client Secret (заавал)
+- `QPAY_INVOICE_CODE` – QPay-д бүртгэгдсэн invoice code
+
 Хуулсан файлууд `UPLOAD_DIR`-ээр заасан санд хадгалагдана.
 
 ## Бүтээгдэхүүний удирдлага

--- a/server/.env.example
+++ b/server/.env.example
@@ -7,3 +7,8 @@ PORT=5001
 
 # Directory for file uploads
 UPLOAD_DIR=server/uploads
+
+# QPay configuration
+QPAY_CLIENT_ID=
+QPAY_CLIENT_SECRET=
+QPAY_INVOICE_CODE=

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -13,7 +13,10 @@ async function getQpayToken() {
     }
 
     const clientId = process.env.QPAY_CLIENT_ID || "FORU";
-    const clientSecret = process.env.QPAY_CLIENT_SECRET || "fMZxsPLj";
+    const clientSecret = process.env.QPAY_CLIENT_SECRET;
+    if (!clientSecret) {
+        throw new Error("QPAY_CLIENT_SECRET is not configured");
+    }
     const base64 = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 
     const resp = await axios.post(

--- a/server/routes/subscription.js
+++ b/server/routes/subscription.js
@@ -16,7 +16,10 @@ async function getQpayToken() {
         return cachedToken;
     }
     const clientId = process.env.QPAY_CLIENT_ID || "FORU";
-    const clientSecret = process.env.QPAY_CLIENT_SECRET || "fMZxsPLj";
+    const clientSecret = process.env.QPAY_CLIENT_SECRET;
+    if (!clientSecret) {
+        throw new Error("QPAY_CLIENT_SECRET is not configured");
+    }
     const base64 = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 
     const resp = await axios.post("https://merchant.qpay.mn/v2/auth/token", {}, {


### PR DESCRIPTION
## Summary
- throw error if `QPAY_CLIENT_SECRET` missing in payment and subscription routes
- document required environment variables
- add QPay entries to `.env.example`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a33d2a308328996b0c22405a94b8