### PR TITLE
Update instructions for realtime feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ bun dev
 
 1. `server/.env.example` файлыг `server/.env` болгон хуулж, `MONGODB_URI`-д өгөгдлийн сангийн холбоосоо бичнэ.
 2. API серверийг `npm run server` (эсвэл `npm run server-dev` автоматаар дахин ачаалуулах) командаар эхлүүлнэ.
-3. MongoDB холболтыг шалгахын тулд `npm run mongo-test` командыг ажиллуулна.
+3. Реалтайм фийдийг идэвхжүүлэхийн тулд `npm run live` (эсвэл `npm run live-dev`) ашиглан Socket.IO серверийг эхлүүлнэ.
+4. MongoDB холболтыг шалгахын тулд `npm run mongo-test` командыг ажиллуулна.
 
 Дараах орчны хувьсагчуудыг `server/.env` файлд тохируулна:
 
 - `MONGODB_URI` – MongoDB-ийн холбоос
 - `PORT` – (сонголттой) серверийн порт
 - `UPLOAD_DIR` – файлууд хадгалагдах санд
+- `REDIS_URL` – Real-time фийдийн Redis холбоос
+- `LIVE_PORT` – Socket.IO серверийн порт
 - `QPAY_CLIENT_ID` – QPay-ийн Client ID
 - `QPAY_CLIENT_SECRET` – QPay-ийн Client Secret (заавал)
 - `QPAY_INVOICE_CODE` – QPay-д бүртгэгдсэн invoice code

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"npm run frontend\" \"npm run server-dev\"",
+    "dev": "concurrently \"npm run frontend\" \"npm run server-dev\" \"npm run live-dev\"",
     "frontend": "next dev",
     "server": "node server/index.js",
     "server-dev": "nodemon server/index.js",
@@ -12,7 +12,9 @@
     "lint": "next lint",
     "test": "jest",
     "clean": "next build && rm -rf .next/cache",
-    "mongo-test": "node mongo-test.mjs"
+    "mongo-test": "node mongo-test.mjs",
+    "live": "node server/live.js",
+    "live-dev": "nodemon server/live.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,12 @@ MONGODB_URI=mongodb://localhost:27017/vone_db
 # Optional server port
 PORT=5001
 
+# Redis connection string for real-time feed
+REDIS_URL=redis://localhost:6379
+
+# Socket.IO live server port
+LIVE_PORT=5002
+
 # Directory for file uploads
 UPLOAD_DIR=server/uploads
 


### PR DESCRIPTION
## Summary
- add live server scripts in `package.json`
- document new `REDIS_URL` and `LIVE_PORT` env vars
- describe how to run the live Socket.IO server

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf322d7208328b0816272c23ea2ac