### PR TITLE
Add MongoDB change stream live feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ bun dev
 - `VAPID_PRIVATE_KEY` – Web-Push нууц түлхүүр
 - `VAPID_EMAIL` – Харицах имэйл хаяг
 
+## Real-time feed (Change Streams)
+
+`server/live-mongo.js` файл нь MongoDB-ийн Change Stream ашиглан `posts` коллекци дээрх шинэ нэмэлтүүдийг Socket.IO-оор дамжуулан илгээдэг. `server/.env`-д дараах хувьсагчууд шаардана:
+
+- `MONGODB_URI`
+- `LIVE_PORT`
+
+Запуск:
+
+```bash
+node server/live-mongo.js
+```
+
+Next.js талд `useLiveFeed` хук нь автомат дахин холболттой. Socket тасарсан тохиолдолд 2 секундийн дараа дахин холбогдоно.
+
+M0 Atlas бүлэглэл Change Streams дэмждэггүй тул энэхүү фийд ажиллахгүй. M2 эсвэл M5 түвшин рүү шинэчлэхийг зөвлөж байна.
+
+PM2/Nginx байршуулах зөвлөмж:
+
+- `pm2 start server/index.js`
+- `pm2 start server/live-mongo.js`
+- Nginx reverse proxy to port `5001` for API and `5002` for Socket.IO
+
 ## Бүтээгдэхүүний удирдлага
 
 Админууд `/dashboard/products` хуудсаар дамжуулан дэлгүүрийн барааг удирдах боломжтой. Энэ хуудсаар зураг оруулж, үнэ засварлах боломжтой.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "clean": "next build && rm -rf .next/cache",
     "mongo-test": "node mongo-test.mjs",
     "live": "node server/live.js",
-    "live-dev": "nodemon server/live.js"
+    "live-dev": "nodemon server/live.js",
+    "live-mongo": "node server/live-mongo.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,7 +5,7 @@ MONGODB_URI=mongodb://localhost:27017/vone_db
 # Optional server port
 PORT=5001
 
-# Redis connection string for real-time feed
+# Redis connection string for Redis-based feed (optional)
 REDIS_URL=redis://localhost:6379
 
 # Socket.IO live server port

--- a/server/live-mongo.js
+++ b/server/live-mongo.js
@@ -1,0 +1,39 @@
+const { createServer } = require('http');
+const express = require('express');
+const { Server } = require('socket.io');
+const mongoose = require('mongoose');
+require('dotenv').config({ path: __dirname + '/.env' });
+
+const app = express();
+const http = createServer(app);
+const io = new Server(http, { cors: { origin: '*' } });
+
+const mongoUri = process.env.MONGODB_URI;
+if (!mongoUri) {
+  console.error('Missing MONGODB_URI');
+  process.exit(1);
+}
+
+mongoose
+  .connect(mongoUri)
+  .then(() => console.log('Connected to MongoDB for change stream'))
+  .catch(err => {
+    console.error('MongoDB connection error', err);
+    process.exit(1);
+  });
+
+const postSchema = new mongoose.Schema({}, { strict: false, collection: 'posts' });
+const Post = mongoose.model('Post', postSchema);
+
+Post.watch([{ $match: { operationType: 'insert' } }]).on('change', change => {
+  if (change.fullDocument) {
+    io.emit('new-post', change.fullDocument);
+  }
+});
+
+io.on('connection', socket => {
+  socket.on('join', room => socket.join(room));
+});
+
+const PORT = process.env.LIVE_PORT || 5002;
+http.listen(PORT, () => console.log('Mongo live server ' + PORT));

--- a/src/app/hooks/useLiveFeed.ts
+++ b/src/app/hooks/useLiveFeed.ts
@@ -8,10 +8,16 @@ let socket: Socket | null = null;
 export default function useLiveFeed(topic: string, addPost: (post: any) => void) {
   useEffect(() => {
     if (!socket) {
-      socket = io(LIVE_URL);
+      socket = io(LIVE_URL, { autoConnect: true });
+
+      socket.on("connect_error", () => {
+        setTimeout(() => socket?.connect(), 2000);
+      });
     }
+
     socket.emit("join", topic);
     socket.on("new-post", addPost);
+
     return () => {
       socket?.off("new-post", addPost);
     };


### PR DESCRIPTION
## Summary
- implement a Socket.IO server that uses MongoDB change streams
- add reconnection handling in `useLiveFeed` hook
- document new change-stream based live feed in README
- update example environment file and npm scripts

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf94fa7a48328a157bae68cea2b7d