### PR TITLE
Add mp3 downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,13 @@ Next.js-ийн талаар илүү ихийг дараах эх сурвалж
 Next.js апп-аа байрлуулах хамгийн хялбар арга бол Next.js-ийн бүтээгчдийн санал болгодог [Vercel Платформ](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)-ыг ашиглах юм.
 
 Дэлгэрэнгүйг манай [Next.js байршуулалтын баримтаас](https://nextjs.org/docs/app/building-your-application/deploying) үзнэ үү.
+
+## MP3 татагч
+
+YouTube линкээс MP3 татахын тулд дараах командыг ашиглана:
+
+```bash
+npm run download-mp3 -- <youtube-ийн-url>
+```
+
+Үүний үр дүнд MP3 файл `tools/mp3` хавтсанд үүснэ.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "live-dev": "nodemon server/live.js",
     "live-mongo": "node server/live-mongo.js",
     "chat": "node server/chat.js",
-    "chat-dev": "nodemon server/chat.js"
+    "chat-dev": "nodemon server/chat.js",
+    "download-mp3": "node tools/mp3/download.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -60,7 +61,10 @@
     "zustand": "^4.4.1",
     "socket.io": "^4.7.2",
     "socket.io-client": "^4.7.2",
-    "ioredis": "^5.3.2"
+    "ioredis": "^5.3.2",
+    "ytdl-core": "^4.11.3",
+    "fluent-ffmpeg": "^2.1.2",
+    "ffmpeg-static": "^5.1.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/tools/mp3/download.js
+++ b/tools/mp3/download.js
@@ -1,0 +1,37 @@
+const ytdl = require('ytdl-core');
+const ffmpeg = require('fluent-ffmpeg');
+const ffmpegPath = require('ffmpeg-static');
+const path = require('path');
+
+async function main() {
+  const url = process.argv[2];
+  if (!url) {
+    console.error('Usage: node download.js <youtube-url>');
+    process.exit(1);
+  }
+
+  try {
+    const info = await ytdl.getInfo(url);
+    const title = info.videoDetails.title
+      .replace(/[\\/:*?"<>|]/g, '')
+      .replace(/\s+/g, '_');
+    const output = path.join(__dirname, `${title}.mp3`);
+
+    await new Promise((resolve, reject) => {
+      ffmpeg(ytdl(url, { filter: 'audioonly', quality: 'highestaudio' }))
+        .setFfmpegPath(ffmpegPath)
+        .format('mp3')
+        .audioBitrate(128)
+        .on('error', reject)
+        .on('end', resolve)
+        .save(output);
+    });
+
+    console.log('Saved:', output);
+  } catch (err) {
+    console.error('Error:', err.message || err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add YouTube mp3 downloader script in `tools/mp3`
- document mp3 download usage
- add dependencies and npm script for mp3 downloader

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cef1efa4c8328b1815314cca69a8e