### PR TITLE
Fix mp3 download route

### DIFF
--- a/src/app/api/mp3/route.ts
+++ b/src/app/api/mp3/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import fs from 'fs';
 import path from 'path';
 import { downloadMP3 } from '../../../../tools/mp3/downloader';
 
@@ -11,6 +12,27 @@ export async function POST(request: Request) {
     const output: string = await downloadMP3(url);
     const filename = path.basename(output);
     return NextResponse.json({ success: true, filename });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'Download failed' }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+  if (!url) {
+    return NextResponse.json({ error: 'Missing url' }, { status: 400 });
+  }
+  try {
+    const output: string = await downloadMP3(url);
+    const filename = path.basename(output);
+    const file = fs.readFileSync(output);
+    return new NextResponse(file, {
+      headers: {
+        'Content-Type': 'audio/mpeg',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
   } catch (err: any) {
     return NextResponse.json({ error: err.message || 'Download failed' }, { status: 500 });
   }

--- a/src/app/tools/mp3/page.tsx
+++ b/src/app/tools/mp3/page.tsx
@@ -4,10 +4,12 @@ import { useState } from 'react';
 export default function Mp3Page() {
   const [url, setUrl] = useState('');
   const [status, setStatus] = useState('');
+  const [link, setLink] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setStatus('Downloading...');
+    setLink(null);
     try {
       const res = await fetch('/api/mp3', {
         method: 'POST',
@@ -17,6 +19,7 @@ export default function Mp3Page() {
       const data = await res.json();
       if (res.ok) {
         setStatus('Saved ' + data.filename);
+        setLink('/mp3/' + data.filename);
       } else {
         setStatus(data.error || 'Error');
       }
@@ -42,6 +45,13 @@ export default function Mp3Page() {
         </button>
       </form>
       {status && <p className="mt-4">{status}</p>}
+      {link && (
+        <p className="mt-2">
+          <a href={link} download className="text-blue-600 underline">
+            MP3 татах
+          </a>
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add GET handler to `/api/mp3` so direct requests can download audio
- allow the MP3 tool page to show a download link once finished

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfb6e9f748328af9e37e80ca2c598