### PR TITLE
Fix MP3 downloader for prod

### DIFF
--- a/src/app/api/mp3/route.ts
+++ b/src/app/api/mp3/route.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import { downloadMP3 } from '../../../../tools/mp3/downloader';
 
+export const runtime = 'nodejs';
+
 export async function POST(request: Request) {
   const { url } = await request.json();
   if (!url) {

--- a/tools/mp3/downloader.ts
+++ b/tools/mp3/downloader.ts
@@ -1,0 +1,31 @@
+import ytdl from 'ytdl-core';
+import ffmpeg from 'fluent-ffmpeg';
+import ffmpegPath from 'ffmpeg-static';
+import path from 'path';
+import fs from 'fs/promises';
+
+ffmpeg.setFfmpegPath(ffmpegPath);   // one-time global
+
+export async function downloadMP3 (url: string): Promise<string> {
+  if (!ytdl.validateURL(url)) throw new Error('Invalid YouTube URL');
+
+  const info   = await ytdl.getInfo(url);
+  const title  = info.videoDetails.title
+                   .replace(/[\\/:*?"<>|]/g, '')
+                   .replace(/\s+/g, '_');
+  const dir    = path.join(process.cwd(), 'public', 'mp3');
+  await fs.mkdir(dir, { recursive: true });
+
+  const out = path.join(dir, `${title}.mp3`);
+
+  await new Promise<void>((res, rej) => {
+    ffmpeg(ytdl(url, { filter: 'audioonly', quality: 'highestaudio' }))
+      .audioBitrate(128)
+      .format('mp3')
+      .on('error', rej)
+      .on('end',  res)
+      .save(out);
+  });
+
+  return out;
+}


### PR DESCRIPTION
## Summary
- add explicit Node runtime for `/api/mp3` route
- implement ESM downloader in TypeScript

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d019b52c88328a4fae74200759ee2