### PR TITLE
Fix fluent-ffmpeg typing error

### DIFF
--- a/types/fluent-ffmpeg.d.ts
+++ b/types/fluent-ffmpeg.d.ts
@@ -1,0 +1,1 @@
+declare module 'fluent-ffmpeg';


### PR DESCRIPTION
## Summary
- add custom declaration for `fluent-ffmpeg` so TypeScript compiles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d04218ec083288aaf8dde98292f4f