### PR TITLE
Implement improved YouTube MP3 service

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
+    "express-rate-limit": "^6.7.0",
     "web-push": "^3.5.0",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",

--- a/src/app/tools/mp3/page.tsx
+++ b/src/app/tools/mp3/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState } from 'react';
-import { API_URL, UPLOADS_URL } from '../../lib/config';
+import { API_URL, BASE_URL } from '../../lib/config';
 
 export default function Mp3Page() {
   const [url, setUrl] = useState('');
@@ -12,15 +12,15 @@ export default function Mp3Page() {
     setStatus('Downloading...');
     setLink(null);
     try {
-      const res = await fetch(`${API_URL}/mp3`, {
+      const res = await fetch(`${API_URL}/mp3/convert`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({ videoUrl: url }),
       });
       const data = await res.json();
       if (res.ok) {
-        setStatus('Saved ' + data.filename);
-        setLink(`${UPLOADS_URL}/mp3/` + data.filename);
+        setStatus('Ready');
+        setLink(BASE_URL + data.filePath);
       } else {
         setStatus(data.error || 'Error');
       }


### PR DESCRIPTION
## Summary
- add rate limit dependency
- replace MP3 router with a production-ready version
- update MP3 download page to use new `/api/mp3/convert` endpoint

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d289e6a7083288fa97f75334b7905