### PR TITLE
Fix post input collapse and clean mobile UI

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
     HomeIcon,
-    PlusCircleIcon,
     BellIcon,
     AcademicCapIcon,
     ChatBubbleLeftRightIcon,
@@ -51,14 +50,6 @@ const BottomNav: React.FC = () => {
                     <HomeIcon className="h-7 w-7 icon-hover-brand" />
                 </button>
 
-                {/* NEW POST */}
-                <button
-                    onClick={() => router.push('/new-post')}
-                    aria-label="New Post"
-                    className="p-1 text-white hover:text-brand"
-                >
-                    <PlusCircleIcon className="h-8 w-8 icon-hover-brand" />
-                </button>
 
                 {/* NOTIFICATIONS */}
                 <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,6 @@ import {
   ChatBubbleOvalLeftIcon,
   ArrowUpTrayIcon,
   ArrowPathIcon,
-  PlusCircleIcon,
 } from "@heroicons/react/24/outline";
 import LoadingSpinner from "./components/LoadingSpinner";
 import PostInput from "./components/PostInput";
@@ -180,6 +179,12 @@ export default function HomePage() {
     setPageNum(1);
     await fetchPosts(1);
     setRefreshing(false);
+  };
+
+  const addNewPost = (post: Post) => {
+    setPosts((prev) => [post, ...prev]);
+    setAllPosts((prev) => [post, ...prev]);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   // ────────────────────────────────────────────────────────────
@@ -406,19 +411,7 @@ export default function HomePage() {
             <>
               {/* Create post */}
               {loggedIn && (
-                <>
-                  <PostInput onPost={refreshPosts} />
-                  {/* Mobile sticky bar */}
-                  <div className="md:hidden sticky top-[68px] z-30 bg-white border-b border-gray-200">
-                    <button
-                      onClick={() => router.push('/new-post')}
-                      className="flex items-center gap-2 w-full p-3"
-                    >
-                      <PlusCircleIcon className="w-6 h-6 text-brand" />
-                      <span className="font-semibold text-brand">New Post</span>
-                    </button>
-                  </div>
-                </>
+                <PostInput onPost={addNewPost} />
               )}
 
               <div className="flex justify-end p-4">


### PR DESCRIPTION
## Summary
- remove the `New Post` button from the mobile bottom nav
- drop the mobile sticky post bar and keep the main post input
- smoothly add a new post to the feed after publishing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6080783c8328b95fdaef4e844002