### PR TITLE
Fix socket cleanup in useChat

### DIFF
--- a/src/app/hooks/useChat.ts
+++ b/src/app/hooks/useChat.ts
@@ -52,7 +52,7 @@ export default function useChat(room: string) {
     };
     socket.on("typing", handleTyping);
     return () => {
-      socket.off("typing", handleTyping);
+      socket?.off("typing", handleTyping);
     };
   }, [room]);
 


### PR DESCRIPTION
## Summary
- prevent TypeScript error in `useChat` cleanup

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module & TS errors)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbab194c88328b3a1a03fc5373596