### PR TITLE
Refactor chat flow

### DIFF
--- a/server/chat.js
+++ b/server/chat.js
@@ -5,6 +5,7 @@ const express = require('express');
 const { Server } = require('socket.io');
 const mongoose = require('mongoose');
 const ChatMessage = require('./models/ChatMessage');
+const Chat = require('./models/Chat');
 
 const app = express();
 const http = createServer(app);
@@ -36,6 +37,11 @@ io.on('connection', socket => {
     } catch (err) {
       console.error('Chat message error', err);
     }
+  });
+
+  socket.on('typing', ({ room }) => {
+    if (!room) return;
+    socket.to(room).emit('typing');
   });
 });
 

--- a/server/models/Chat.js
+++ b/server/models/Chat.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+const { Schema, model, models } = mongoose;
+
+const ChatSchema = new Schema(
+  {
+    participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }]
+  },
+  { timestamps: true }
+);
+
+const Chat = models.Chat || model('Chat', ChatSchema);
+module.exports = Chat;

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -1,20 +1,70 @@
 const express = require('express');
 const router = express.Router();
+const Chat = require('../models/Chat');
 const ChatMessage = require('../models/ChatMessage');
 const authenticateToken = require('../middleware/authMiddleware');
 
-// Fetch last 50 messages for a room
-router.get('/:room', authenticateToken, async (req, res) => {
+// list chats for logged in user
+router.get('/', authenticateToken, async (req, res) => {
   try {
-    const { room } = req.params;
-    const messages = await ChatMessage.find({ room })
-      .sort({ createdAt: -1 })
-      .limit(50)
+    const chats = await Chat.find({ participants: req.user._id })
+      .sort({ updatedAt: -1 })
+      .populate({
+        path: 'participants',
+        select: 'username profilePicture',
+      });
+    res.json(chats);
+  } catch (err) {
+    console.error('Chat list error', err);
+    res.status(500).json({ error: 'Failed to fetch chats' });
+  }
+});
+
+// get or create chat with specific user
+router.post('/with/:userId', authenticateToken, async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const participants = [req.user._id.toString(), userId].sort();
+    let chat = await Chat.findOne({ participants: { $all: participants, $size: 2 } });
+    if (!chat) {
+      chat = await Chat.create({ participants });
+    }
+    await chat.populate({
+      path: 'participants',
+      select: 'username profilePicture',
+    });
+    res.json(chat);
+  } catch (err) {
+    console.error('Chat create error', err);
+    res.status(500).json({ error: 'Failed to create chat' });
+  }
+});
+
+// get messages for chat
+router.get('/:chatId/messages', authenticateToken, async (req, res) => {
+  try {
+    const { chatId } = req.params;
+    const messages = await ChatMessage.find({ room: chatId })
+      .sort({ createdAt: 1 })
       .populate('sender', 'username profilePicture');
-    res.json(messages.reverse());
+    res.json(messages);
   } catch (err) {
     console.error('Chat fetch error', err);
     res.status(500).json({ error: 'Failed to fetch messages' });
+  }
+});
+
+// send a message
+router.post('/:chatId/messages', authenticateToken, async (req, res) => {
+  try {
+    const { chatId } = req.params;
+    const { text } = req.body;
+    const msg = await ChatMessage.create({ room: chatId, text, sender: req.user._id });
+    const full = await msg.populate('sender', 'username profilePicture');
+    res.json(full);
+  } catch (err) {
+    console.error('Chat send error', err);
+    res.status(500).json({ error: 'Failed to send message' });
   }
 });
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,41 +1,77 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import ChatList, { Conversation } from "../components/chat/ChatList";
 import ChatWindow from "../components/chat/ChatWindow";
 import { useAuth } from "../context/AuthContext";
-
-const demoConversations: Conversation[] = [
-  {
-    id: "u1",
-    user: { id: "u1", name: "John Doe", avatar: "/img/default-avatar.png", online: true },
-    lastMessage: "Hey there!",
-    timestamp: new Date().toISOString(),
-    unread: 2,
-  },
-  {
-    id: "u2",
-    user: { id: "u2", name: "Jane", avatar: "/img/default-avatar.png", online: false },
-    lastMessage: "Let's meet tomorrow at the cafe to discuss the project details.",
-    timestamp: new Date().toISOString(),
-    unread: 0,
-  },
-];
+import { API_URL } from "../lib/config";
 
 export default function ChatPage() {
-  const { loggedIn } = useAuth();
-  const [active, setActive] = useState<string | null>(demoConversations[0].id);
+  const { loggedIn, user } = useAuth();
+  const params = useSearchParams();
+  const targetUser = params.get("user");
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [active, setActive] = useState<string | null>(null);
 
-  const activeConv = demoConversations.find((c) => c.id === active)!;
+  // load chat list
+  useEffect(() => {
+    if (!user) return;
+    const token = localStorage.getItem("token") || "";
+    fetch(`${API_URL}/chat`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => res.json())
+      .then((chats) => {
+        const convs: Conversation[] = chats.map((c: any) => {
+          const other = c.participants.find((p: any) => p._id !== user._id);
+          return {
+            id: c._id,
+            user: { id: other._id, name: other.username, avatar: other.profilePicture },
+            lastMessage: "",
+            timestamp: c.updatedAt,
+            unread: 0,
+          };
+        });
+        setConversations(convs);
+      })
+      .catch(err => console.error("Chat list", err));
+  }, [user]);
+
+  // if ?user= param provided create/get chat
+  useEffect(() => {
+    if (!targetUser || !user) return;
+    const token = localStorage.getItem("token") || "";
+    fetch(`${API_URL}/chat/with/${targetUser}`, { method: "POST", headers: { Authorization: `Bearer ${token}` } })
+      .then(res => res.json())
+      .then((chat) => {
+        const other = chat.participants.find((p: any) => p._id !== user._id);
+        const conv: Conversation = {
+          id: chat._id,
+          user: { id: other._id, name: other.username, avatar: other.profilePicture },
+          lastMessage: "",
+          timestamp: chat.updatedAt,
+          unread: 0,
+        };
+        setActive(chat._id);
+        setConversations((prev) => {
+          const exists = prev.find(c => c.id === chat._id);
+          return exists ? prev : [conv, ...prev];
+        });
+      })
+      .catch(err => console.error("Chat open", err));
+  }, [targetUser, user]);
+
+  const activeConv = conversations.find(c => c.id === active);
 
   return (
     <div className="flex h-[calc(100vh-64px)]">
       <aside className="hidden md:block w-1/3 border-r border-supportBorder">
         <h2 className="p-3 font-semibold">Мессеж</h2>
-        <ChatList conversations={demoConversations} activeId={active || undefined} onSelect={setActive} />
+        <ChatList conversations={conversations} activeId={active || undefined} onSelect={setActive} />
       </aside>
       <div className="flex-1 relative">
         <div className="md:hidden border-b border-supportBorder p-3 font-semibold">Мессеж</div>
-        <ChatWindow chatId={activeConv.id} user={activeConv.user} onBack={() => setActive(null)} />
+        {activeConv && (
+          <ChatWindow chatId={activeConv.id} user={activeConv.user} onBack={() => setActive(null)} />
+        )}
         {loggedIn && (
           <button
             className="fixed bottom-4 right-4 bg-brand text-white w-12 h-12 rounded-full shadow-lg"

--- a/src/app/components/chat/ChatWindow.tsx
+++ b/src/app/components/chat/ChatWindow.tsx
@@ -17,7 +17,7 @@ interface ChatWindowProps {
 }
 
 export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
-  const { messages, sendMessage, startTyping, typing } = useChat(chatId);
+  const { messages, sendMessage, startTyping, typing, loading } = useChat(chatId);
   const [text, setText] = useState("");
   const endRef = useRef<HTMLDivElement | null>(null);
 
@@ -64,7 +64,12 @@ export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
         {user.online && <span className="w-2 h-2 rounded-full bg-green-500" />}
       </div>
       <div className="flex-1 overflow-y-auto p-3 space-y-2">
-        {messages.map((msg: ChatMessage) => (
+        {loading && (
+          <div className="flex justify-center py-4">
+            <div className="w-6 h-6 border-2 border-brand border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+        {!loading && messages.map((msg: ChatMessage) => (
           <div
             key={msg._id}
             className={`flex ${msg.sender._id === me ? "justify-end" : "justify-start"}`}

--- a/src/app/hooks/useChat.ts
+++ b/src/app/hooks/useChat.ts
@@ -17,13 +17,16 @@ let typingTimeout: ReturnType<typeof setTimeout> | null = null;
 export default function useChat(room: string) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [typing, setTyping] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const token = typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
-    fetch(`${API_URL}/chat/${room}`, { headers: { Authorization: `Bearer ${token}` } })
+    setLoading(true);
+    fetch(`${API_URL}/chat/${room}/messages`, { headers: { Authorization: `Bearer ${token}` } })
       .then(res => res.json())
       .then((data: ChatMessage[]) => setMessages(data))
-      .catch(err => console.error("Fetch messages error", err));
+      .catch(err => console.error("Fetch messages error", err))
+      .finally(() => setLoading(false));
   }, [room]);
 
   useEffect(() => {
@@ -66,5 +69,5 @@ export default function useChat(room: string) {
     socket.emit("typing", { room, sender });
   };
 
-  return { messages, sendMessage, startTyping, typing };
+  return { messages, sendMessage, startTyping, typing, loading };
 }

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -5,8 +5,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { FaCheckCircle } from "react-icons/fa";
 import HomeFeedPost from "../../components/HomeFeedPost";
-import ChatList, { Conversation } from "../../components/chat/ChatList";
-import ChatWindow from "../../components/chat/ChatWindow";
 import axios from "axios";
 import { BASE_URL } from "../../lib/config";
 import { getImageUrl } from "../../lib/getImageUrl";
@@ -34,23 +32,6 @@ export default function PublicProfilePage() {
     const [loading, setLoading] = useState(true);
     const [postLoading, setPostLoading] = useState(false);
     const [error, setError] = useState("");
-    const demoConversations: Conversation[] = [
-        {
-            id: "u1",
-            user: { id: "u1", name: "John Doe", avatar: "/img/default-avatar.png", online: true },
-            lastMessage: "Hey there!",
-            timestamp: new Date().toISOString(),
-            unread: 1,
-        },
-        {
-            id: "u2",
-            user: { id: "u2", name: "Jane", avatar: "/img/default-avatar.png", online: false },
-            lastMessage: "See you soon.",
-            timestamp: new Date().toISOString(),
-            unread: 0,
-        },
-    ];
-    const [activeChat, setActiveChat] = useState<string | null>(demoConversations[0].id);
 
     // Share handler
     const handleShareAdd = (newPost: Post) => {
@@ -200,18 +181,13 @@ export default function PublicProfilePage() {
                     ))}
                 </div>
             </div>
-            <div className="max-w-xl mx-auto px-4 mt-8">
-                <h3 className="text-xl font-bold mb-3">Мессеж</h3>
-                <div className="border rounded h-96 flex flex-col md:flex-row overflow-hidden">
-                    <div className="md:w-1/3 border-r">
-                        <ChatList conversations={demoConversations} activeId={activeChat || undefined} onSelect={setActiveChat} />
-                    </div>
-                    <div className="flex-1">
-                        {activeChat && (
-                            <ChatWindow chatId={activeChat} user={demoConversations.find(c => c.id === activeChat)!.user} onBack={() => setActiveChat(null)} />
-                        )}
-                    </div>
-                </div>
+            <div className="max-w-xl mx-auto px-4 mt-8 text-center">
+                <Link
+                    href={`/chat?user=${userId}`}
+                    className="inline-block bg-brand text-white px-4 py-2 rounded"
+                >
+                    Мессеж
+                </Link>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- create `Chat` model
- support creating chats and sending messages in chat routes
- add typing support in socket chat server
- show spinner while chat messages load
- load chat on `/chat` page and link from profiles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc00d3e8c8328a563538721ed91f1