### PR TITLE
Minimal futuristic layout redesign

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -3,11 +3,11 @@
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
-    HomeIcon,
-    BellIcon,
-    AcademicCapIcon,
-    ChatBubbleLeftRightIcon,
-} from "@heroicons/react/24/outline";
+  TbHome,
+  TbBell,
+  TbMessageCircle,
+  TbBook2,
+} from "react-icons/tb";
 import { useNotifications } from "../context/NotificationContext";
 
 const BottomNav: React.FC = () => {
@@ -34,30 +34,27 @@ const BottomNav: React.FC = () => {
     return (
         <>
         <nav
-            className={`fixed bottom-0 left-0 w-full md:hidden transition-all border-t border-supportBorder shadow-lg bg-[#212121] text-white ${
+            className={`fixed bottom-0 left-0 w-full md:hidden transition-all border-t border-supportBorder bg-[#171717] text-white ${
                 scrolledDown ? "" : ""
             }`}
         >
             <div
                 className="flex justify-around items-center py-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]"
             >
-                {/* HOME */}
                 <button
                     onClick={() => router.push("/")}
                     aria-label="Home"
-                    className="p-1 text-white hover:text-brand"
+                    className="p-1 text-white/60 hover:text-[#30c9e8]"
                 >
-                    <HomeIcon className="h-7 w-7 icon-hover-brand" />
+                    <TbHome size={24} />
                 </button>
 
-
-                {/* NOTIFICATIONS */}
                 <button
                     onClick={() => router.push("/notifications")}
                     aria-label="Notifications"
-                    className="relative p-1 text-white hover:text-brand"
+                    className="relative p-1 text-white/60 hover:text-[#30c9e8]"
                 >
-                    <BellIcon className="h-7 w-7 icon-hover-brand" />
+                    <TbBell size={24} />
                     {unreadCount > 0 && (
                         <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
                             {unreadCount}
@@ -65,22 +62,20 @@ const BottomNav: React.FC = () => {
                     )}
                 </button>
 
-                {/* CHAT */}
                 <button
                     onClick={() => router.push("/chat")}
                     aria-label="Chat"
-                    className="p-1 text-white hover:text-brand"
+                    className="p-1 text-white/60 hover:text-[#30c9e8]"
                 >
-                    <ChatBubbleLeftRightIcon className="h-7 w-7 icon-hover-brand" />
+                    <TbMessageCircle size={24} />
                 </button>
 
-                {/* CLASSROOM */}
                 <button
                     onClick={() => router.push("/classroom")}
                     aria-label="Classroom"
-                    className="p-1 text-white hover:text-brand"
+                    className="p-1 text-white/60 hover:text-[#30c9e8]"
                 >
-                    <AcademicCapIcon className="h-7 w-7 icon-hover-brand" />
+                    <TbBook2 size={24} />
                 </button>
 
             </div>

--- a/src/app/components/IconSidebar.tsx
+++ b/src/app/components/IconSidebar.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useNotifications } from "../context/NotificationContext";
+import {
+  TbHome,
+  TbUsers,
+  TbBell,
+  TbMessageCircle,
+  TbBook2,
+  TbUser,
+} from "react-icons/tb";
+
+const links = [
+  { href: "/", icon: TbHome },
+  { href: "/users", icon: TbUsers },
+  { href: "/classroom", icon: TbBook2 },
+  { href: "/notifications", icon: TbBell },
+  { href: "/chat", icon: TbMessageCircle },
+  { href: "/profile", icon: TbUser },
+];
+
+export default function IconSidebar() {
+  const pathname = usePathname();
+  const { unreadCount } = useNotifications();
+  return (
+    <aside className="hidden md:flex fixed top-0 left-0 h-full w-16 bg-[#171717] py-6 flex-col items-center space-y-6">
+      {links.map(({ href, icon: Icon }) => {
+        const active = pathname === href;
+        if (href === "/notifications") {
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`relative text-white/60 hover:text-[#30c9e8] transition-colors ${active ? "text-[#30c9e8]" : ""}`}
+            >
+              {unreadCount > 0 && (
+                <span className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
+                  {unreadCount}
+                </span>
+              )}
+              <Icon size={24} />
+            </Link>
+          );
+        }
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`text-white/60 hover:text-[#30c9e8] transition-colors ${active ? "text-[#30c9e8]" : ""}`}
+          >
+            <Icon size={24} />
+          </Link>
+        );
+      })}
+    </aside>
+  );
+}

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -5,42 +5,14 @@ import { usePathname } from "next/navigation";
 import { AuthProvider } from "../context/AuthContext";
 import { CartProvider } from "../context/CartContext";
 import { ThemeProvider } from "../context/ThemeContext";
-import { NotificationProvider, useNotifications } from "../context/NotificationContext";
-import {
-  BellIcon,
-  HomeIcon,
-  UserGroupIcon,
-  AcademicCapIcon,
-  ChatBubbleLeftRightIcon,
-} from "@heroicons/react/24/outline";
+import { NotificationProvider } from "../context/NotificationContext";
+import IconSidebar from "./IconSidebar";
 import Header from "./Header";
 import BottomNav from "./BottomNav";
 import SidebarControl from "./SidebarControl";
 import NavigationLoader from "./NavigationLoader";
 import LoadingOverlay from "./LoadingOverlay";
 import Link from "next/link";
-
-function NotificationNavItem() {
-  const { unreadCount } = useNotifications();
-  return (
-    <li>
-      <Link
-        href="/notifications"
-        className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
-      >
-        <BellIcon className="w-6 h-6 group-hover:text-brand" />
-        <span className="flex items-center">
-          Notifications
-          {unreadCount > 0 && (
-            <span className="ml-1 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
-              {unreadCount}
-            </span>
-          )}
-        </span>
-      </Link>
-    </li>
-  );
-}
 
 export default function LayoutClient({ children }: { children: React.ReactNode }) {
   const [mountLoading, setMountLoading] = useState(true);
@@ -67,60 +39,13 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
             <SidebarControl />
             <Header />
             <main className="flex-grow flex flex-col md:flex-row gap-0 pt-16">
-              <aside
-                id="left-sidebar"
-                className="hidden md:block w-full md:w-1/4 border-r border-supportBorder sticky top-16 h-[calc(100vh-80px)] overflow-y-auto fade-in-up"
-              >
-                <nav>
-                  <ul className="space-y-1">
-                    <li>
-                      <Link
-                        href="/"
-                        className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
-                      >
-                        <HomeIcon className="w-6 h-6 group-hover:text-brand" />
-                        <span>Нүүр</span>
-                      </Link>
-                    </li>
-                  <li>
-                    <Link
-                      href="/users"
-                      className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
-                    >
-                      <UserGroupIcon className="w-6 h-6 group-hover:text-brand" />
-                      <span>Гишүүд</span>
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      href="/classroom"
-                      className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
-                    >
-                      <AcademicCapIcon className="w-6 h-6 group-hover:text-brand" />
-                  <span>Хичээл</span>
-                    </Link>
-                  </li>
-                  <NotificationNavItem />
-                  <li>
-                    <Link
-                      href="/chat"
-                      className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
-                    >
-                      <ChatBubbleLeftRightIcon className="w-6 h-6 group-hover:text-brand" />
-                      <span>Чат</span>
-                    </Link>
-                  </li>
-                  </ul>
-                </nav>
-              </aside>
-              <div
-                className={`w-full ${isWidePage ? "md:w-full" : "md:w-1/2 md:border-r md:border-supportBorder"}`}
-              >
-                <div className="space-y-6">{children}</div>
+              <IconSidebar />
+              <div className="flex-1 flex justify-center md:ml-16">
+                <div className={`w-full max-w-xl ${isWidePage ? "md:w-full" : ""} bg-[#212121] shadow-lg rounded-xl p-4`}>{children}</div>
               </div>
               <aside
                 id="right-sidebar"
-                className="hidden md:block w-full md:w-1/4 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
+                className="hidden md:block w-1/4 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
               ></aside>
             </main>
           </div>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { FaCheckCircle } from "react-icons/fa";
+import { TbUserPlus, TbUserMinus, TbMessageCircle } from "react-icons/tb";
 import HomeFeedPost from "../../components/HomeFeedPost";
 import axios from "axios";
 import { BASE_URL } from "../../lib/config";
@@ -135,101 +136,62 @@ export default function PublicProfilePage() {
     const isOwnProfile = viewer?._id === userId;
 
     return (
-        <div className="min-h-screen bg-white text-black font-sans">
-            {/* Top Navigation */}
-            <div className="fixed top-0 left-0 w-full h-12 flex items-center px-4 backdrop-blur-md z-10 bg-black/60">
-                <button
-                    onClick={() => router.back()}
-                    aria-label="Back"
-                    className="mr-2 text-black"
-                >
-                    &#8592;
-                </button>
-                <h1 className="font-bold flex-1 text-center">
-                    {userData.username}
-                </h1>
-            </div>
-
-            {/* Banner */}
-            <div className="h-40 bg-[#0d0d0d] relative mt-12">
-                {userData.coverImage && (
+        <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
+            <div className="max-w-xl mx-auto relative bg-[#212121] rounded-xl shadow-lg p-6">
+                {userData.profilePicture && (
                     <Image
-                        src={getImageUrl(userData.coverImage)}
-                        alt="Cover"
-                        width={800}
-                        height={160}
-                        className="absolute inset-0 w-full h-full object-cover"
+                        src={getImageUrl(userData.profilePicture)}
+                        alt="Profile"
+                        width={96}
+                        height={96}
+                        className="absolute -top-12 right-6 w-24 h-24 rounded-full border-2 border-[#171717] object-cover"
                     />
                 )}
-                <div className="absolute -bottom-16 left-4 w-32 h-32 rounded-full border-4 border-[#0d0d0d] overflow-hidden bg-gray-800">
-                    {userData.profilePicture && (
-                        <Image
-                            src={getImageUrl(userData.profilePicture)}
-                            alt="Profile"
-                            width={128}
-                            height={128}
-                            className="w-full h-full object-cover"
-                        />
-                    )}
-                </div>
-            </div>
-
-            {/* Meta */}
-            <div className="pt-20 px-4">
-                <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
-                        <h1 className="text-2xl font-bold">{userData.username}</h1>
-                        {isPro && <FaCheckCircle className="text-brand" />}
-                    </div>
-                    {loggedIn && !isOwnProfile && (
-                        <div className="flex gap-2">
-                            {viewer?.following?.includes(userId) ? (
-                                <button onClick={handleUnfollow} className="text-sm px-3 py-1 rounded border border-brand text-brand">Following</button>
-                            ) : (
-                                <button onClick={handleFollow} className="text-sm px-3 py-1 rounded border border-brand text-brand">Follow</button>
-                            )}
-                            <Link href={`/chat?user=${userId}`} className="text-sm px-3 py-1 rounded bg-brand text-white">Message</Link>
-                        </div>
-                    )}
-                </div>
-                {userData.rating && (
-                    <p className="text-sm text-gray-400">
-                        ★ {userData.rating} үнэлгээ
-                    </p>
-                )}
+                <h1 className="mt-12 text-2xl font-bold flex items-center gap-1">
+                    {userData.username}
+                    {isPro && <FaCheckCircle className="text-[#30c9e8]" />}
+                </h1>
                 {userData.location && (
-                    <p className="text-sm text-gray-400">
-                        Байршил: {userData.location}
-                    </p>
+                    <p className="text-sm text-white/60">{userData.location}</p>
                 )}
-                <div className="flex gap-6 mt-2 text-sm">
-                    <Link href={`/profile/${userId}/followers`} className="hover:underline">
-                        {userData.followers ? userData.followers.length : 0} Followers
-                    </Link>
-                    <Link href={`/profile/${userId}/following`} className="hover:underline">
-                        {userData.following ? userData.following.length : 0} Following
-                    </Link>
+                <div className="flex gap-4 mt-2 text-xs text-white/60">
+                    <Link href={`/profile/${userId}/followers`}>{userData.followers ? userData.followers.length : 0} Followers</Link>
+                    <Link href={`/profile/${userId}/following`}>{userData.following ? userData.following.length : 0} Following</Link>
                 </div>
+                {loggedIn && !isOwnProfile && (
+                    <div className="absolute top-4 left-4 flex gap-4">
+                        {viewer?.following?.includes(userId) ? (
+                            <button onClick={handleUnfollow} aria-label="Unfollow" className="text-white/60 hover:text-[#30c9e8]">
+                                <TbUserMinus size={20} />
+                            </button>
+                        ) : (
+                            <button onClick={handleFollow} aria-label="Follow" className="text-white/60 hover:text-[#30c9e8]">
+                                <TbUserPlus size={20} />
+                            </button>
+                        )}
+                        <Link href={`/chat?user=${userId}`} aria-label="Message" className="text-white/60 hover:text-[#30c9e8]">
+                            <TbMessageCircle size={20} />
+                        </Link>
+                    </div>
+                )}
             </div>
 
-            {/* Posts Section */}
-            <div className="w-full max-w-xl mt-8 px-4">
-                <h2 className="text-xl font-semibold mb-4">Нийтлэлүүд</h2>
+            <div className="mt-6 flex justify-center border-b border-white/20">
+                <button className="px-4 py-2 text-white border-b-2 border-[#30c9e8]">Threads</button>
+                <button className="px-4 py-2 text-white/60">Replies</button>
+                <button className="px-4 py-2 text-white/60">Media</button>
+            </div>
+
+            <div className="w-full max-w-xl mx-auto mt-6 px-4">
                 {postLoading && (
                     <p className="text-gray-400 mb-2">Ачааллаж байна...</p>
                 )}
                 {!postLoading && userPosts.length === 0 && (
-                    <p className="text-gray-400">
-                        Энэ хэрэглэгч нийтлэлгүй байна.
-                    </p>
+                    <p className="text-gray-400">Энэ хэрэглэгч нийтлэлгүй байна.</p>
                 )}
                 <div className="space-y-4">
                     {userPosts.map((post) => (
-                        <HomeFeedPost
-                            key={post._id}
-                            post={post}
-                            onShareAdd={handleShareAdd}
-                        />
+                        <HomeFeedPost key={post._id} post={post} onShareAdd={handleShareAdd} />
                     ))}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- implement futuristic icon sidebar using Tabler icons
- modernize bottom nav with matching icon style
- simplify main layout to use the new sidebar and centered content card
- redesign public profile page without cover photo

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd5e1d7788328903fdc4bda9ffbfb