### PR TITLE
Refine centered layouts across pages

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -9,8 +9,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import {
-  Bars3Icon,
-  XMarkIcon,
   PencilSquareIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
@@ -43,7 +41,6 @@ export default function ClassroomPage() {
   const [newUrl, setNewUrl] = useState('');
   const [newDesc, setNewDesc] = useState('');
   const [editing, setEditing] = useState<Lesson | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Fetch lessons
   useEffect(() => {
@@ -124,30 +121,12 @@ export default function ClassroomPage() {
   };
 
   return (
-    <div className="flex flex-col md:flex-row min-h-screen text-black">
-      <button
-        className="md:hidden absolute top-2 left-2 z-20 p-2 bg-white rounded-full shadow"
-        onClick={() => setSidebarOpen(true)}
-        aria-label="Open lessons"
-      >
-        <Bars3Icon className="w-6 h-6 text-gray-600" />
-      </button>
-      {sidebarOpen && (
-        <div className="fixed inset-0 bg-black/40 z-10 md:hidden" onClick={() => setSidebarOpen(false)} />
-      )}
-      <aside
-        className={`bg-white p-4 border-r border-gray-200 overflow-y-auto md:h-screen md:sticky md:top-0 fixed inset-y-0 left-0 z-20 w-72 transform transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}
-      >
-        <button
-          className="md:hidden absolute top-2 right-2 p-1"
-          onClick={() => setSidebarOpen(false)}
-          aria-label="Close lessons"
-        >
-          <XMarkIcon className="w-5 h-5 text-gray-600" />
-        </button>
-        <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-          <BookOpenIcon className="w-6 h-6" /> Classroom
-        </h2>
+    <div className="min-h-screen py-4 text-black">
+      <div className="max-w-3xl mx-auto flex flex-col md:flex-row gap-y-6 md:gap-x-8">
+        <aside className="md:flex-1 md:w-1/2 bg-white p-4 border border-gray-200 rounded">
+          <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+            <BookOpenIcon className="w-6 h-6" /> Classroom
+          </h2>
 
         {isAdmin && (
           <div className="bg-white shadow rounded-lg p-3 mb-4">
@@ -162,23 +141,23 @@ export default function ClassroomPage() {
               placeholder="YouTube video URL"
               value={newUrl}
               onChange={(e) => setNewUrl(e.target.value)}
-              className="w-full border p-2 rounded mb-2 focus:ring"
+              className="w-full rounded-lg mb-2 p-2 bg-inputBg text-inputText focus:ring-1 focus:ring-brand focus:outline-none"
             />
             <input
               type="text"
               placeholder="Lesson title"
               value={newTitle}
               onChange={(e) => setNewTitle(e.target.value)}
-              className="w-full border p-2 rounded mb-2 focus:ring"
+              className="w-full rounded-lg mb-2 p-2 bg-inputBg text-inputText focus:ring-1 focus:ring-brand focus:outline-none"
             />
             <textarea
               placeholder="Short description"
               value={newDesc}
               onChange={(e) => setNewDesc(e.target.value)}
-              className="w-full border p-2 rounded mb-2 focus:ring"
+              className="w-full rounded-lg mb-2 p-2 bg-inputBg text-inputText focus:ring-1 focus:ring-brand focus:outline-none"
             />
             {validForm && (
-              <div className="flex items-center gap-3 mb-2">
+              <div className="flex items-center justify-center gap-3 mb-2">
                 <img
                   src={`https://img.youtube.com/vi/${extractVideoId(newUrl)}/hqdefault.jpg`}
                   alt="thumbnail"
@@ -220,7 +199,7 @@ export default function ClassroomPage() {
           {lessons.map((lesson) => (
             <div
               key={lesson._id}
-              className={`flex items-center p-2 rounded shadow cursor-pointer ${selected && selected._id === lesson._id ? 'bg-cyan-50' : 'bg-white'}`}
+              className={`flex items-center p-2 rounded cursor-pointer ${selected && selected._id === lesson._id ? 'bg-cyan-50' : 'bg-white'}`}
               onClick={() => setSelected(lesson)}
             >
               <CheckIcon

--- a/src/app/components/HomeFeedPost.tsx
+++ b/src/app/components/HomeFeedPost.tsx
@@ -164,7 +164,7 @@ export default function HomeFeedPost({ post, onDelete, onShareAdd }: Props) {
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="bg-[#212121] text-white p-4 grid gap-4 shadow-sm"
+      className="bg-[#212121] text-white p-4 grid gap-4"
     >
       <div className="grid grid-cols-[auto,1fr] gap-5 group">
         {/* Avatar */}
@@ -214,7 +214,7 @@ export default function HomeFeedPost({ post, onDelete, onShareAdd }: Props) {
                   </svg>
                 </button>
                 {menuOpen && (
-                  <div className="absolute right-0 mt-1 bg-[#333] text-white border border-gray-700 rounded shadow">
+                  <div className="absolute right-0 mt-1 bg-[#333] text-white border border-gray-700 rounded">
                     <button
                       onClick={handleEdit}
                       className="block px-3 py-1 text-sm hover:bg-gray-600 w-full text-left"
@@ -336,7 +336,7 @@ export default function HomeFeedPost({ post, onDelete, onShareAdd }: Props) {
                     <input
                       type="text"
                       placeholder="Reply..."
-                      className="flex-1 text-xs border border-gray-300 rounded p-1"
+                      className="flex-1 text-xs rounded p-1 bg-inputBg text-inputText focus:ring-1 focus:ring-brand focus:outline-none"
                       value={replyTexts[comment._id] || ""}
                       onChange={(e) =>
                         setReplyTexts((prev) => ({ ...prev, [comment._id]: e.target.value }))
@@ -357,7 +357,7 @@ export default function HomeFeedPost({ post, onDelete, onShareAdd }: Props) {
             <input
               type="text"
               placeholder="Add a comment..."
-              className="flex-1 text-sm border border-gray-300 rounded p-2"
+              className="flex-1 text-sm rounded p-2 bg-inputBg text-inputText focus:ring-1 focus:ring-brand focus:outline-none"
               value={commentText}
               onChange={(e) => setCommentText(e.target.value)}
             />

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -40,8 +40,12 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
             <Header />
             <main className="flex-grow flex flex-col md:flex-row gap-0 pt-16">
               <IconSidebar />
-              <div className="flex-1 flex justify-center md:ml-16">
-                <div className={`w-full md:max-w-xl ${isWidePage ? "md:w-full" : ""} bg-[#212121] shadow-sm p-4`}>{children}</div>
+              <div className="flex-1 flex justify-center md:ml-16 px-3">
+                <div
+                  className={`w-full mx-auto ${isWidePage ? "md:max-w-7xl" : "md:max-w-2xl"} bg-[#212121] p-4`}
+                >
+                  {children}
+                </div>
               </div>
               <aside
                 id="right-sidebar"

--- a/src/app/components/NextGenPostInput.tsx
+++ b/src/app/components/NextGenPostInput.tsx
@@ -99,7 +99,7 @@ export default function NextGenPostInput({ onPost }: Props) {
   return (
     <form
       onSubmit={handleSubmit}
-      className="relative bg-[#212121] shadow-sm flex flex-col sm:flex-row items-center gap-3 w-full px-4 py-3"
+      className="relative bg-[#212121] flex flex-col sm:flex-row items-center gap-3 w-full px-4 py-3"
     >
       {user?.profilePicture ? (
         <Image

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -66,7 +66,7 @@ export default function NotificationsPage() {
   if (!user) return <div className="p-4">Please login to view notifications.</div>;
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold">Notifications</h1>
       {notifications.length === 0 ? (
         <p>No notifications.</p>
@@ -75,7 +75,7 @@ export default function NotificationsPage() {
           {notifications.map((n) => (
             <li
               key={n._id}
-              className={`border p-2 rounded ${n.read ? "" : "bg-gray-100 dark:bg-gray-800"}`}
+              className={`p-2 rounded ${n.read ? "" : "bg-gray-100 dark:bg-gray-800"}`}
             >
               {n.type === "like" && (
                 <span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -336,18 +336,8 @@ export default function HomePage() {
       )}
 
 
-      {/* Outer grid */}
-      <div
-        className="mx-auto max-w-5xl w-full grid"
-        style={{
-          gridTemplateColumns:
-            "var(--barcelona-threadline-column-width) minmax(0, 1fr)",
-        }}
-      >
-
-
-        {/* Main content */}
-        <main>
+      <div className="mx-auto w-full max-w-2xl px-4">
+        <main className="space-y-6">
           {/* Prompt login */}
           {!loggedIn && (
             <div className="bg-secondary p-6 text-center space-y-3">

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -137,7 +137,7 @@ export default function PublicProfilePage() {
 
     return (
         <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
-            <div className="max-w-xl mx-auto p-6 flex flex-col items-center text-center">
+            <div className="max-w-2xl mx-auto p-6 flex flex-col items-center text-center">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -187,7 +187,7 @@ export default function PublicProfilePage() {
                 <button className="px-4 py-2 text-white/60">Media</button>
             </div>
 
-            <div className="w-full max-w-xl mx-auto mt-6 px-4">
+            <div className="w-full max-w-2xl mx-auto mt-6 px-4">
                 {postLoading && (
                     <p className="text-gray-400 mb-2">Ачааллаж байна...</p>
                 )}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -162,7 +162,7 @@ export default function MyOwnProfilePage() {
 
     return (
         <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
-            <div className="max-w-xl mx-auto p-6 flex flex-col items-center text-center">
+            <div className="max-w-2xl mx-auto p-6 flex flex-col items-center text-center">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -197,7 +197,7 @@ export default function MyOwnProfilePage() {
             )}
 
             {/* My posts */}
-            <div className="max-w-xl mx-auto px-4 mt-4">
+            <div className="max-w-2xl mx-auto px-4 mt-4">
                 <h3 className="text-xl font-bold mb-3">Миний нийтлэлүүд</h3>
                 {loadingPosts ? (
                     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- center main column in `LayoutClient` with flexible widths
- remove post/input shadows and borders
- simplify newsfeed and classroom page containers
- unify profile and notifications layouts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fac5d756c83288846a2430e836554