### PR TITLE
Fix JSX closing tag in classroom page

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -263,5 +263,6 @@ export default function ClassroomPage() {
         )}
       </main>
     </div>
+  </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix missing closing `div` in `src/app/classroom/page.tsx`

## Testing
- `tsc --pretty false src/app/classroom/page.tsx` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685fb39e8cdc8328b21909193e8346b3