### PR TITLE
Improve mobile feed width

### DIFF
--- a/src/app/components/HomeFeedPost.tsx
+++ b/src/app/components/HomeFeedPost.tsx
@@ -164,7 +164,7 @@ export default function HomeFeedPost({ post, onDelete, onShareAdd }: Props) {
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="bg-[#212121] text-white p-4 grid gap-4"
+      className="bg-[#212121] text-white p-4 grid gap-4 rounded-none sm:rounded-lg"
     >
       <div className="grid grid-cols-[auto,1fr] gap-5 group">
         {/* Avatar */}

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -42,7 +42,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
               <IconSidebar />
               <div className="flex-1 flex justify-center px-2 md:px-0">
                 <div
-                  className={`w-full max-w-full mx-auto ${isWidePage ? "md:max-w-7xl" : "md:max-w-2xl"} bg-[#212121] p-4`}
+                  className={`w-full max-w-full mx-auto ${isWidePage ? "md:max-w-7xl" : "md:max-w-2xl"} bg-[#212121] p-4 rounded-none sm:rounded-lg`}
                 >
                   {children}
                 </div>

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -66,7 +66,7 @@ export default function NotificationsPage() {
   if (!user) return <div className="p-4">Please login to view notifications.</div>;
 
   return (
-    <div className="max-w-2xl mx-auto p-4 space-y-4">
+    <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 py-4 space-y-4 rounded-none sm:rounded-lg">
       <h1 className="text-2xl font-bold">Notifications</h1>
       {notifications.length === 0 ? (
         <p>No notifications.</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -336,7 +336,7 @@ export default function HomePage() {
       )}
 
 
-      <div className="mx-auto w-full max-w-2xl px-4">
+      <div className="w-full max-w-full md:max-w-2xl mx-auto px-2 sm:px-4">
         <main className="space-y-6">
           {/* Prompt login */}
           {!loggedIn && (
@@ -393,7 +393,7 @@ export default function HomePage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: idx * 0.02 }}
-                    className="bg-white p-6 grid gap-4 border-b-0 sm:border-b sm:border-gray-200 dark:bg-[#2a2a2a] sm:dark:border-gray-700 dark:text-white"
+                    className="bg-white p-6 grid gap-4 border-b-0 sm:border-b sm:border-gray-200 dark:bg-[#2a2a2a] sm:dark:border-gray-700 dark:text-white rounded-none sm:rounded-lg"
                   >
                     {/* Header */}
                     <div className="grid grid-cols-[auto,1fr] gap-5 group">

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -137,7 +137,7 @@ export default function PublicProfilePage() {
 
     return (
         <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
-            <div className="max-w-2xl mx-auto p-6 flex flex-col items-center text-center">
+            <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -187,7 +187,7 @@ export default function PublicProfilePage() {
                 <button className="px-4 py-2 text-white/60">Media</button>
             </div>
 
-            <div className="w-full max-w-2xl mx-auto mt-6 px-4">
+            <div className="w-full max-w-full md:max-w-2xl mx-auto mt-6 px-4">
                 {postLoading && (
                     <p className="text-gray-400 mb-2">Ачааллаж байна...</p>
                 )}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -162,7 +162,7 @@ export default function MyOwnProfilePage() {
 
     return (
         <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
-            <div className="max-w-2xl mx-auto p-6 flex flex-col items-center text-center">
+            <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -197,7 +197,7 @@ export default function MyOwnProfilePage() {
             )}
 
             {/* My posts */}
-            <div className="max-w-2xl mx-auto px-4 mt-4">
+            <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 mt-4">
                 <h3 className="text-xl font-bold mb-3">Миний нийтлэлүүд</h3>
                 {loadingPosts ? (
                     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- allow feed container to use full width on mobile
- flatten border radius on small screens
- center posts with responsive width on profile and notification pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc5358bc08328979311239b81064c