### PR TITLE
Improve layout centering

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -122,7 +122,7 @@ export default function ClassroomPage() {
 
   return (
     <div className="min-h-screen py-4 text-black">
-      <div className="max-w-3xl mx-auto flex flex-col md:flex-row gap-y-6 md:gap-x-8">
+      <div className="flex flex-col md:flex-row gap-y-6 md:gap-x-8">
         <aside className="md:flex-1 md:w-1/2 bg-white p-4 border border-gray-200 rounded">
           <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
             <BookOpenIcon className="w-6 h-6" /> Classroom

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -40,9 +40,9 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
             <Header />
             <main className="flex flex-row min-h-screen pt-16">
               <IconSidebar />
-              <div className="flex-1 flex justify-center px-2 md:px-0">
+              <div className="flex-1 flex justify-center items-start">
                 <div
-                  className={`w-full max-w-full mx-auto ${isWidePage ? "md:max-w-7xl" : "md:max-w-2xl"} bg-[#212121] p-4 rounded-none sm:rounded-lg`}
+                  className={`w-full max-w-full px-2 md:px-0 mx-auto ${isWidePage ? "md:max-w-7xl" : "md:max-w-2xl"} bg-[#212121] p-4 rounded-none sm:rounded-lg`}
                 >
                   {children}
                 </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -335,9 +335,7 @@ export default function HomePage() {
         </div>
       )}
 
-
-      <div className="w-full max-w-full md:max-w-2xl mx-auto px-2 sm:px-4">
-        <main className="space-y-6">
+      <main className="space-y-6">
           {/* Prompt login */}
           {!loggedIn && (
             <div className="bg-secondary p-6 text-center space-y-3">
@@ -644,7 +642,6 @@ export default function HomePage() {
             </>
         )}
         </main>
-      </div>
     </div>
   );
 }

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -137,7 +137,7 @@ export default function PublicProfilePage() {
 
     return (
         <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
-            <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
+            <div className="px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -187,7 +187,7 @@ export default function PublicProfilePage() {
                 <button className="px-4 py-2 text-white/60">Media</button>
             </div>
 
-            <div className="w-full max-w-full md:max-w-2xl mx-auto mt-6 px-4">
+            <div className="mt-6 px-4">
                 {postLoading && (
                     <p className="text-gray-400 mb-2">Ачааллаж байна...</p>
                 )}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -162,7 +162,7 @@ export default function MyOwnProfilePage() {
 
     return (
         <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
-            <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
+            <div className="px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -197,7 +197,7 @@ export default function MyOwnProfilePage() {
             )}
 
             {/* My posts */}
-            <div className="w-full max-w-full md:max-w-2xl mx-auto px-4 mt-4">
+            <div className="px-4 mt-4">
                 <h3 className="text-xl font-bold mb-3">Миний нийтлэлүүд</h3>
                 {loadingPosts ? (
                     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- update `LayoutClient` so the center column is properly centered
- remove local centering wrappers from newsfeed, profile pages, and classroom

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc691c65c8328906e778a84ce2896