### PR TITLE
Add layout demo components

### DIFF
--- a/docs/demo/HomeFeedPage.tsx
+++ b/docs/demo/HomeFeedPage.tsx
@@ -1,0 +1,22 @@
+export default function HomeFeedPage() {
+  return (
+    <div className="space-y-4 py-4">
+      <div className="flex items-start space-x-3">
+        <div className="w-10 h-10 bg-gray-500 rounded-full" />
+        <textarea
+          className="w-full min-h-12 bg-transparent border-b border-gray-600 focus:border-brand transition"
+          placeholder="What's happening?"
+        />
+      </div>
+      {[...Array(3)].map((_, i) => (
+        <div key={i} className="dark:bg-[#2a2a2a] rounded-lg shadow-sm p-4">
+          <div className="flex items-center space-x-3 mb-2">
+            <div className="w-10 h-10 bg-gray-500 rounded-full" />
+            <span>User {i + 1}</span>
+          </div>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/demo/LayoutClient.tsx
+++ b/docs/demo/LayoutClient.tsx
@@ -1,0 +1,31 @@
+"use client";
+import React from "react";
+
+export default function LayoutClient({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-row min-h-screen bg-[#171717]">
+      {/* Left sidebar */}
+      <aside id="left" className="w-16 shrink-0 flex flex-col items-center">
+        {/* icons */}
+      </aside>
+      {/* Center area */}
+      <main id="center" className="flex-1 flex justify-center items-start">
+        <div
+          className="w-full max-w-full sm:max-w-full md:max-w-2xl px-2 sm:px-3 md:px-0 mx-auto"
+        >
+          {children}
+        </div>
+      </main>
+      {/* Optional right sidebar */}
+      <aside id="right" className="w-64 shrink-0 hidden lg:block" />
+
+      {/* Bottom nav for mobile */}
+      <nav className="fixed bottom-0 w-full flex justify-around bg-[#171717] md:hidden">
+        {/* nav icons */}
+      </nav>
+    </div>
+  );
+}
+
+/* Centering magic: the `mx-auto` on the container combines with `flex-1` on the main area to keep the content perfectly centered. Adjust `md:max-w-2xl` to tweak the desktop width. */
+


### PR DESCRIPTION
## Summary
- add example `LayoutClient` implementing center container behavior
- add sample `HomeFeedPage` demonstrating centered feed

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fce13a6648328ab8297674c83bc66