### PR TITLE
Refactor layout structure

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -34,7 +34,7 @@ const BottomNav: React.FC = () => {
     return (
         <>
         <nav
-            className={`fixed bottom-0 left-0 w-full md:hidden transition-all border-t border-supportBorder bg-[#171717] text-white ${
+            className={`fixed bottom-0 left-0 w-full sm:hidden transition-all border-t border-supportBorder bg-[#171717] text-white ${
                 scrolledDown ? "" : ""
             }`}
         >

--- a/src/app/components/IconSidebar.tsx
+++ b/src/app/components/IconSidebar.tsx
@@ -23,7 +23,7 @@ export default function IconSidebar() {
   const pathname = usePathname();
   const { unreadCount } = useNotifications();
   return (
-    <aside id="left-sidebar" className="hidden md:flex w-16 shrink-0 bg-[#171717] py-6 flex-col items-center space-y-6">
+    <nav className="py-6 flex flex-col items-center space-y-6">
       {links.map(({ href, icon: Icon }) => {
         const active = pathname === href;
         if (href === "/notifications") {
@@ -52,6 +52,6 @@ export default function IconSidebar() {
           </Link>
         );
       })}
-    </aside>
+    </nav>
   );
 }

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -12,12 +12,11 @@ import BottomNav from "./BottomNav";
 import SidebarControl from "./SidebarControl";
 import NavigationLoader from "./NavigationLoader";
 import LoadingOverlay from "./LoadingOverlay";
-import Link from "next/link";
+
 
 export default function LayoutClient({ children }: { children: React.ReactNode }) {
   const [mountLoading, setMountLoading] = useState(true);
   const pathname = usePathname();
-  const isWidePage = pathname.startsWith("/dashboard") || pathname.startsWith("/classroom");
 
   useEffect(() => {
     const timer = setTimeout(() => setMountLoading(false), 500);
@@ -35,24 +34,17 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
               pathname.startsWith("/users") ||
               pathname.startsWith("/profile")) && <LoadingOverlay />}
           <NavigationLoader />
-          <div className="max-w-7xl w-full mx-auto md:px-6">
-            <SidebarControl />
-            <Header />
-            <main className="flex flex-row min-h-screen pt-16">
-              <IconSidebar />
-              <div className="flex-1 flex justify-center items-start">
-                <div
-                  className={`w-full max-w-full px-2 md:px-0 mx-auto ${isWidePage ? "md:max-w-7xl" : "md:max-w-2xl"} bg-[#212121] p-4 rounded-none sm:rounded-lg`}
-                >
-                  {children}
-                </div>
-              </div>
-              <aside
-                id="right-sidebar"
-                className="hidden md:block w-1/4 shrink-0 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
-              ></aside>
-            </main>
-          </div>
+          <SidebarControl />
+          <Header />
+          <aside id="left" className="hidden sm:flex w-16 shrink-0 flex-col items-center bg-[#1a1a1a]">
+            <IconSidebar />
+          </aside>
+          <main id="center" className="flex-1 flex justify-center items-start bg-[#171717] pt-16">
+            <div className="w-full max-w-full sm:max-w-full md:max-w-2xl mx-auto px-2 md:px-0">
+              {children}
+            </div>
+          </main>
+          <aside id="right" className="hidden lg:flex w-16 shrink-0 flex-col items-center bg-[#1a1a1a]" />
           <BottomNav />
           </NotificationProvider>
         </AuthProvider>

--- a/src/app/components/SidebarControl.tsx
+++ b/src/app/components/SidebarControl.tsx
@@ -5,8 +5,8 @@ import { useEffect } from 'react';
 export default function SidebarControl() {
   const pathname = usePathname();
   useEffect(() => {
-    const left = document.getElementById('left-sidebar');
-    const right = document.getElementById('right-sidebar');
+    const left = document.getElementById('left');
+    const right = document.getElementById('right');
     if (!left || !right) return;
     if (pathname.startsWith('/dashboard') || pathname.startsWith('/classroom')) {
       left.style.display = 'none';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="mn" className="dark">
-            <body className="flex flex-col min-h-screen bg-[#171717] text-white font-sans">
+            <body className="flex text-white font-sans">
                 <LayoutClient>{children}</LayoutClient>
             </body>
         </html>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -136,7 +136,7 @@ export default function PublicProfilePage() {
     const isOwnProfile = viewer?._id === userId;
 
     return (
-        <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
+        <div className="min-h-screen text-white font-sans pt-14">
             <div className="px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
                 {userData.profilePicture && (
                     <Image

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -161,7 +161,7 @@ export default function MyOwnProfilePage() {
         : false;
 
     return (
-        <div className="min-h-screen bg-[#212121] text-white font-sans pt-14">
+        <div className="min-h-screen text-white font-sans pt-14">
             <div className="px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
                 {userData.profilePicture && (
                     <Image


### PR DESCRIPTION
## Summary
- adjust root layout to use flex body
- add sidebar/main structure in LayoutClient
- simplify IconSidebar
- fix sidebar visibility control
- tweak BottomNav mobile breakpoint
- drop dark wrappers from profile pages

`mx-auto` + `flex-1 justify-center` is the centering magic.

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd21151508328a190298cc20716df