### PR TITLE
Remove border radius from feed wrappers

### DIFF
--- a/src/app/components/HomeFeedPost.tsx
+++ b/src/app/components/HomeFeedPost.tsx
@@ -164,7 +164,7 @@ export default function HomeFeedPost({ post, onDelete, onShareAdd }: Props) {
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="bg-[#212121] text-white p-4 grid gap-4 rounded-none sm:rounded-lg"
+      className="bg-[#212121] text-white p-4 grid gap-4 rounded-none"
     >
       <div className="grid grid-cols-[auto,1fr] gap-5 group">
         {/* Avatar */}

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -110,7 +110,7 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
   };
 
   return (
-    <div className="bg-white p-6 grid gap-4 border-b border-gray-200">
+    <div className="bg-white p-6 grid gap-4 border-b border-gray-200 rounded-none">
       <div className="flex gap-3 group">
         {user.profilePicture ? (
           <Image
@@ -154,7 +154,7 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
                   </svg>
                 </button>
                 {menuOpen && (
-                  <div className="absolute right-0 mt-1 bg-white border rounded shadow">
+                  <div className="absolute right-0 mt-1 bg-white border shadow rounded-none">
                     <button
                       onClick={handleEdit}
                       className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -378,7 +378,7 @@ export default function HomePage() {
               </div>
 
               {/* Posts list */}
-              <div className="m-0 p-0">
+              <div className="m-0 p-0 rounded-none">
               {loadingPosts && pageNum === 1 ? (
                   <LoadingSpinner />
                 ) : (
@@ -391,7 +391,7 @@ export default function HomePage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: idx * 0.02 }}
-                    className="bg-white p-6 grid gap-4 border-b-0 sm:border-b sm:border-gray-200 dark:bg-[#2a2a2a] sm:dark:border-gray-700 dark:text-white rounded-none sm:rounded-lg"
+                    className="bg-white p-6 grid gap-4 border-b-0 sm:border-b sm:border-gray-200 dark:bg-[#2a2a2a] sm:dark:border-gray-700 dark:text-white rounded-none"
                   >
                     {/* Header */}
                     <div className="grid grid-cols-[auto,1fr] gap-5 group">

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -137,7 +137,7 @@ export default function PublicProfilePage() {
 
     return (
         <div className="min-h-screen text-white font-sans pt-14">
-            <div className="px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
+            <div className="px-4 py-6 flex flex-col items-center text-center rounded-none">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -194,7 +194,7 @@ export default function PublicProfilePage() {
                 {!postLoading && userPosts.length === 0 && (
                     <p className="text-gray-400">Энэ хэрэглэгч нийтлэлгүй байна.</p>
                 )}
-                <div className="divide-y divide-gray-700 space-y-0">
+                <div className="divide-y divide-gray-700 space-y-0 rounded-none">
                     {userPosts.map((post) => (
                         <HomeFeedPost key={post._id} post={post} onShareAdd={handleShareAdd} />
                     ))}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -162,7 +162,7 @@ export default function MyOwnProfilePage() {
 
     return (
         <div className="min-h-screen text-white font-sans pt-14">
-            <div className="px-4 py-6 flex flex-col items-center text-center rounded-none sm:rounded-lg">
+            <div className="px-4 py-6 flex flex-col items-center text-center rounded-none">
                 {userData.profilePicture && (
                     <Image
                         src={getImageUrl(userData.profilePicture)}
@@ -206,7 +206,7 @@ export default function MyOwnProfilePage() {
                         ))}
                     </div>
                 ) : userPosts.length > 0 ? (
-                    <div className="divide-y divide-gray-700 space-y-0">
+                    <div className="divide-y divide-gray-700 space-y-0 rounded-none">
                         {userPosts.map((post) => (
                             <HomeFeedPost
                                 key={post._id}


### PR DESCRIPTION
## Summary
- update `PostCard` root element to use `rounded-none`
- strip radius from menu dropdown
- remove rounded corners on home feed posts
- ensure profile page wrappers have no radius

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd91f0cb88328b169dd8e0f42abe4