### PR TITLE
Add posting trust & moderation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ bun dev
 - `VAPID_PUBLIC_KEY` – Web-Push олон нийтэд түгээх түлхүүр
 - `VAPID_PRIVATE_KEY` – Web-Push нууц түлхүүр
 - `VAPID_EMAIL` – Харицах имэйл хаяг
+- `HCAPTCHA_SECRET` – hCaptcha баталгаажуулалтын нууц
+
+Toxicity модел ашиглахын тулд `@xenova/transformers` санг суулгана:
+
+```bash
+npm install @xenova/transformers
+```
 
 ## Real-time feed (Change Streams)
 

--- a/controllers/posts.ts
+++ b/controllers/posts.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from 'express';
+import Post from '../models/Post';
+import User from '../models/User';
+import { adjustTrust } from '../utils/adjustTrust';
+
+export async function createPost(req: Request, res: Response) {
+  const { content } = req.body;
+  const image = (req as any).file?.filename;
+
+  const post = await Post.create({
+    user: (req as any).user._id,
+    content,
+    image,
+    shadow: (req as any).shadow || false,
+  });
+
+  if (!(req as any).shadow) {
+    await adjustTrust((req as any).user._id, 2);
+  }
+
+  res.status(201).json({ post });
+}
+
+export async function likePost(req: Request, res: Response) {
+  const post = await Post.findById(req.params.id);
+  if (!post) return res.status(404).json({ error: 'Post not found' });
+  if (post.likes.includes((req as any).user._id)) {
+    return res.status(400).json({ error: 'Already liked' });
+  }
+  post.likes.push((req as any).user._id);
+  await post.save();
+  await adjustTrust((req as any).user._id, 1);
+  res.json({ likes: post.likes.length });
+}
+
+export async function commentPost(req: Request, res: Response) {
+  const post = await Post.findById(req.params.id);
+  if (!post) return res.status(404).json({ error: 'Post not found' });
+  post.comments.push({ user: (req as any).user._id, content: req.body.content });
+  await post.save();
+  await adjustTrust((req as any).user._id, 1);
+  res.json({ comments: post.comments });
+}
+
+export async function sharePost(req: Request, res: Response) {
+  const post = await Post.findById(req.params.id);
+  if (!post) return res.status(404).json({ error: 'Post not found' });
+  post.shares = (post.shares || 0) + 1;
+  await post.save();
+  await adjustTrust((req as any).user._id, 1);
+  res.json({ shares: post.shares });
+}
+
+export async function reportPost(req: Request, res: Response) {
+  const post = await Post.findById(req.params.id);
+  if (!post) return res.status(404).json({ error: 'Post not found' });
+  post.reports = (post.reports || 0) + 1;
+  await post.save();
+  await adjustTrust(post.user, -10);
+  if (post.reports >= 3) post.shadow = true;
+  await post.save();
+  res.json({ reports: post.reports });
+}

--- a/middleware/postGuards.ts
+++ b/middleware/postGuards.ts
@@ -1,0 +1,123 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import rateLimit from 'express-rate-limit';
+import RedisStore from 'rate-limit-redis';
+import Redis from 'ioredis';
+import { pipeline } from '@xenova/transformers';
+import User from '../models/User';
+import Post from '../models/Post';
+import { profanityList } from '../profanityList';
+
+const redis = new Redis(process.env.REDIS_URL || '');
+
+// ---------------------- verifyJWT ----------------------
+export async function verifyJWT(req: Request, res: Response, next: NextFunction) {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  try {
+    const decoded = jwt.verify(auth.split(' ')[1], process.env.JWT_SECRET || 'secret') as any;
+    const user = await User.findById(decoded.id);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+    (req as any).user = user;
+    next();
+  } catch {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+}
+
+// ---------------------- rateLimiter --------------------
+const hitKey = (ip: string) => `post-limit-hits:${ip}`;
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: req => `${req.ip}:${(req as any).user?._id || ''}`,
+  store: new RedisStore({ sendCommand: (...args: string[]) => redis.call(...args) }),
+  handler: async (req, res) => {
+    await redis.incr(hitKey(req.ip));
+    await redis.expire(hitKey(req.ip), 60 * 60);
+    res.status(429).json({ error: 'Too many posts' });
+  },
+});
+export const rateLimiter = limiter;
+
+// ------------------- youngAccountThrottle ---------------
+export async function youngAccountThrottle(req: Request, res: Response, next: NextFunction) {
+  const user = (req as any).user;
+  const ageMs = Date.now() - new Date(user.createdAt).getTime();
+  if (ageMs < 24 * 60 * 60 * 1000) {
+    const oneHour = new Date(Date.now() - 60 * 60 * 1000);
+    const count = await Post.countDocuments({ user: user._id, createdAt: { $gte: oneHour } });
+    if (count >= 1) return res.status(429).json({ error: 'Too many posts' });
+  }
+  next();
+}
+
+// ---------------------- hCaptcha fallback ---------------
+export async function hCaptchaFallback(req: Request, res: Response, next: NextFunction) {
+  const ipHits = parseInt((await redis.get(hitKey(req.ip))) || '0');
+  const user = (req as any).user;
+  const ageMs = Date.now() - new Date(user.createdAt).getTime();
+  const hasLink = /https?:\/\//i.test(req.body.content || '') || !!(req as any).file;
+  if (ipHits >= 2 || (ageMs < 24 * 60 * 60 * 1000 && hasLink)) {
+    const token = req.body.hCaptchaToken;
+    if (!token) return res.status(400).json({ error: 'hCaptcha required' });
+    try {
+      const resp = await fetch('https://hcaptcha.com/siteverify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: `response=${token}&secret=${process.env.HCAPTCHA_SECRET}`,
+      });
+      const data = await resp.json();
+      if (!data.success) return res.status(400).json({ error: 'Invalid hCaptcha' });
+    } catch {
+      return res.status(400).json({ error: 'Invalid hCaptcha' });
+    }
+  }
+  next();
+}
+
+// --------------------- mongolianProfanity ---------------
+export async function mongolianProfanity(req: Request, res: Response, next: NextFunction) {
+  const content = req.body.content || '';
+  if (!profanityList.some(r => r.test(content))) return next();
+  const user = (req as any).user;
+  user.strikes = (user.strikes || 0) + 1;
+  await user.save();
+  if (user.strikes === 1) {
+    return res.status(200).json({ warning: true });
+  }
+  user.mutedUntil = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  await user.save();
+  return res.status(403).json({ error: 'Muted for 24h' });
+}
+
+// -------------------- toxicityModelHF -------------------
+const toxicityPromise = pipeline('text-classification', 'papluca/xlm-roberta-base-toxicity');
+export async function toxicityModelHF(req: Request, res: Response, next: NextFunction) {
+  if (!req.body.content) return next();
+  const classifier = await toxicityPromise;
+  const result = await classifier(req.body.content);
+  if (result[0]?.score > 0.85) return res.status(400).json({ error: 'Toxic content' });
+  next();
+}
+
+// ----------------------- shadowBanCheck -----------------
+export function shadowBanCheck(req: Request, _res: Response, next: NextFunction) {
+  const user = (req as any).user;
+  if (user.trustScore < -20) (req as any).shadow = true;
+  next();
+}
+
+// ------------------------- canPost ----------------------
+export function canPost(req: Request, res: Response, next: NextFunction) {
+  const user = (req as any).user;
+  if (user.mutedUntil && new Date(user.mutedUntil) > new Date()) {
+    return res.status(403).json({ error: 'Muted' });
+  }
+  next();
+}

--- a/models/User.ts
+++ b/models/User.ts
@@ -1,0 +1,25 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IUser extends Document {
+  username: string;
+  email: string;
+  passwordHash: string;
+  createdAt: Date;
+  profilePicture: string;
+  trustScore: number;
+  strikes: number;
+  mutedUntil: Date | null;
+}
+
+const UserSchema = new Schema<IUser>({
+  username: { type: String, required: true, unique: true },
+  email: { type: String, required: true, unique: true },
+  passwordHash: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  profilePicture: { type: String, default: '' },
+  trustScore: { type: Number, default: 0 },
+  strikes: { type: Number, default: 0 },
+  mutedUntil: { type: Date, default: null }
+});
+
+export default model<IUser>('User', UserSchema);

--- a/profanityList.ts
+++ b/profanityList.ts
@@ -1,0 +1,6 @@
+export const profanityList: RegExp[] = [
+  /чөтгөр/i,
+  /банзал/i,
+  /novsh/i,
+  /%dornod%/i // example extra
+];

--- a/routes/posts.ts
+++ b/routes/posts.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import multer from 'multer';
+import {
+  verifyJWT,
+  rateLimiter,
+  youngAccountThrottle,
+  hCaptchaFallback,
+  mongolianProfanity,
+  toxicityModelHF,
+  shadowBanCheck,
+  canPost,
+} from '../middleware/postGuards';
+import {
+  createPost,
+  likePost,
+  commentPost,
+  sharePost,
+  reportPost,
+} from '../controllers/posts';
+
+const upload = multer({ dest: 'uploads/' });
+const router = Router();
+
+router.post(
+  '/',
+  verifyJWT,
+  rateLimiter,
+  youngAccountThrottle,
+  hCaptchaFallback,
+  mongolianProfanity,
+  toxicityModelHF,
+  shadowBanCheck,
+  canPost,
+  upload.single('image'),
+  createPost
+);
+
+router.post('/:id/like', verifyJWT, likePost);
+router.post('/:id/comment', verifyJWT, commentPost);
+router.post('/:id/share', verifyJWT, sharePost);
+router.post('/:id/report', verifyJWT, reportPost);
+
+export default router;

--- a/utils/adjustTrust.ts
+++ b/utils/adjustTrust.ts
@@ -1,0 +1,6 @@
+import { Types } from 'mongoose';
+import User from '../models/User';
+
+export async function adjustTrust(userId: Types.ObjectId, delta: number) {
+  await User.findByIdAndUpdate(userId, { $inc: { trustScore: delta } }).exec();
+}


### PR DESCRIPTION
## Summary
- add trust fields to User schema
- implement postGuard middleware chain
- create trust-aware post controllers
- expose routes using guard chain
- adjust trust utility and profanity list
- document new env vars and HF install

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869b13878748328a4077c473ef48d6e