### PR TITLE
Fix Express type declaration error

### DIFF
--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -1,0 +1,1 @@
+declare module 'express';


### PR DESCRIPTION
## Summary
- add a custom type declaration for `express` to avoid missing types error

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b31f70808328bd531b64d77adf30