### PR TITLE
Fix compile error in posts controller

### DIFF
--- a/controllers/posts.ts
+++ b/controllers/posts.ts
@@ -8,7 +8,7 @@ interface CreatePostBody {
 }
 
 export async function createPost(
-  req: Request<{}, {}, CreatePostBody>,
+  req: Request,
   res: Response
 ) {
   const { content } = req.body || {};
@@ -45,7 +45,7 @@ interface CommentPostBody {
 }
 
 export async function commentPost(
-  req: Request<{}, {}, CommentPostBody>,
+  req: Request,
   res: Response
 ) {
   const post = await Post.findById(req.params.id);

--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -1,1 +1,22 @@
-declare module 'express';
+declare module 'express' {
+  interface Request<P = any, ResBody = any, ReqBody = any, ReqQuery = any> {
+    params: P;
+    body: ReqBody;
+    query: ReqQuery;
+    headers: any;
+    [key: string]: any;
+  }
+
+  interface Response<ResBody = any> {
+    status(code: number): this;
+    json(body: ResBody): this;
+    [key: string]: any;
+  }
+
+  type NextFunction = (err?: any) => void;
+
+  const express: any;
+
+  export { Request, Response, NextFunction };
+  export default express;
+}


### PR DESCRIPTION
## Summary
- correct Express `Request` usage in `posts.ts`
- stub Express types to support generics without full `@types/express`

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails to find many external modules)*

------
https://chatgpt.com/codex/tasks/task_e_6869b6c17f608328ba0460c3c690af6e