### PR TITLE
Adjust classroom mobile sidebar and selected state

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -136,7 +136,7 @@ export default function ClassroomPage() {
         <div className="fixed inset-0 bg-black/40 z-10 md:hidden" onClick={() => setSidebarOpen(false)} />
       )}
       <aside
-        className={`bg-[#212121] p-4 border-r border-gray-200 overflow-y-auto md:h-screen md:sticky md:top-0 fixed inset-y-0 left-0 z-20 w-72 transform transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}
+        className={`bg-[#212121] p-6 border-r border-gray-200 overflow-y-auto md:h-screen md:sticky md:top-0 fixed inset-y-0 left-0 z-20 w-64 md:w-80 transform transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}
       >
         <button
           className="md:hidden absolute top-2 right-2 p-1"
@@ -220,7 +220,7 @@ export default function ClassroomPage() {
           {lessons.map((lesson) => (
             <div
               key={lesson._id}
-              className={`flex items-center p-2 rounded shadow cursor-pointer hover:bg-[#323232] ${selected && selected._id === lesson._id ? 'bg-cyan-50' : 'bg-[#212121]'}`}
+              className={`flex items-center p-2 rounded shadow cursor-pointer hover:bg-[#323232] ${selected && selected._id === lesson._id ? 'bg-[#323232]' : 'bg-[#212121]'}`}
               onClick={() => setSelected(lesson)}
             >
               <CheckIcon


### PR DESCRIPTION
## Summary
- update classroom sidebar sizing/padding for mobile
- remove white background when selecting a lesson

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8de6b6cc8328894d06c86500006e