### PR TITLE
Fix chat socket URL fallback

### DIFF
--- a/src/app/lib/config.ts
+++ b/src/app/lib/config.ts
@@ -4,4 +4,9 @@ export const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 // Default to localhost Socket.IO server when developing.
 export const LIVE_URL = process.env.NEXT_PUBLIC_LIVE_URL ?? 'http://localhost:5002';
 // Chat Socket.IO server
-export const CHAT_URL = process.env.NEXT_PUBLIC_CHAT_URL ?? 'http://localhost:5001';
+// Use the same host as the backend if NEXT_PUBLIC_CHAT_URL is not provided.
+export const CHAT_URL =
+  process.env.NEXT_PUBLIC_CHAT_URL ??
+  (process.env.NEXT_PUBLIC_BACKEND_URL
+    ? process.env.NEXT_PUBLIC_BACKEND_URL.replace(/\/api$/, '')
+    : 'http://localhost:5001');


### PR DESCRIPTION
## Summary
- fix fallback value for `CHAT_URL` so it uses the backend host if no env var is supplied

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8dc0f4188328ab8899219e662024