### PR TITLE
Fix mobile chat layout

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -99,10 +99,16 @@ export default function ChatPage() {
   }, [active]);
 
   return (
-    <div className="flex h-[calc(100vh-64px)]">
-      <aside className="hidden md:block w-1/3 border-r border-supportBorder">
+    <div className="flex h-[calc(100vh-64px)] pb-20 md:pb-0">
+      <aside
+        className={`${active ? "hidden" : ""} md:block w-full md:w-1/3 border-r border-supportBorder overflow-y-auto`}
+      >
         <h2 className="p-3 font-semibold">Мессеж</h2>
-        <ChatList conversations={conversations} activeId={active || undefined} onSelect={setActive} />
+        <ChatList
+          conversations={conversations}
+          activeId={active || undefined}
+          onSelect={setActive}
+        />
       </aside>
       <div className="flex-1 relative">
         <div className="md:hidden border-b border-supportBorder p-3 font-semibold">Мессеж</div>

--- a/src/app/components/chat/ChatWindow.tsx
+++ b/src/app/components/chat/ChatWindow.tsx
@@ -44,7 +44,7 @@ export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full pb-20 md:pb-0">
       <div className="flex items-center p-3 border-b border-supportBorder">
         {onBack && (
           <button className="md:hidden mr-2" onClick={onBack} aria-label="Back">


### PR DESCRIPTION
## Summary
- show chat list on mobile devices when no conversation is selected
- add bottom padding so chat page and window aren't hidden behind the bottom nav

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b92819f988328b19f34028932afb9