### PR TITLE
Update reply input style

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,12 +39,6 @@ html.dark body {
     color: #F5F6F8;
 }
 
-html.dark input,
-html.dark textarea,
-html.dark select {
-    background-color: #1E1E1E;
-    color: #AFAFAF;
-}
 
 html.dark .bg-white {
     background-color: #212121 !important;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -558,7 +558,7 @@ export default function HomePage() {
                                   <input
                                     type="text"
                                     placeholder="Reply..."
-                                    className="flex-1 text-xs border border-gray-300 rounded p-1"
+                                    className="w-full max-w-full flex-1 text-xs bg-[#f5f6fa] text-[#111] placeholder-[#9ca3af] border border-[#e5e7eb] rounded-[6px] py-[6px] px-[10px] focus:outline-none focus:ring-2 focus:ring-[#3b82f6]"
                                     value={replyTexts[comment._id] || ""}
                                     onChange={(e) =>
                                       setReplyTexts((prev) => ({


### PR DESCRIPTION
## Summary
- remove dark mode input override so inputs match card styling
- style reply input with light background, gray border, blue focus ring

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9867da488328a4784ff6ce348857