### PR TITLE
Fix clipped avatars in chat

### DIFF
--- a/src/app/components/chat/ChatList.tsx
+++ b/src/app/components/chat/ChatList.tsx
@@ -34,10 +34,10 @@ export default function ChatList({ conversations, activeId, onSelect }: ChatList
                 alt={conv.user.name}
                 width={40}
                 height={40}
-                className="rounded-full"
+                className="avatar"
               />
             ) : (
-              <div className="w-10 h-10 rounded-full bg-brand text-white flex items-center justify-center text-lg">
+              <div className="avatar bg-brand text-white flex items-center justify-center text-lg">
                 {conv.user.name.charAt(0).toUpperCase()}
               </div>
             )}

--- a/src/app/components/chat/ChatWindow.tsx
+++ b/src/app/components/chat/ChatWindow.tsx
@@ -58,12 +58,12 @@ export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
             <Image
               src={`${BASE_URL}${user.avatar}`}
               alt={user.name}
-              width={32}
-              height={32}
-              className="rounded-full"
+              width={40}
+              height={40}
+              className="avatar"
             />
           ) : (
-            <div className="w-8 h-8 rounded-full bg-brand text-white flex items-center justify-center text-sm">
+            <div className="avatar bg-brand text-white flex items-center justify-center text-sm">
               {user.name.charAt(0).toUpperCase()}
             </div>
           )}
@@ -91,9 +91,9 @@ export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
                 <Image
                   src={`${BASE_URL}${msg.sender.profilePicture || ""}`}
                   alt={msg.sender.username}
-                  width={24}
-                  height={24}
-                  className="rounded-full"
+                  width={40}
+                  height={40}
+                  className="avatar"
                 />
               )}
               <div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,15 @@
     border-radius: 0; /* Example custom override */
 }
 
+/* Standard avatar styling */
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
 /* Override or add your custom light-theme styles here. */
 html,
 body {


### PR DESCRIPTION
## Summary
- add `.avatar` CSS class
- ensure all chat avatars use the new styling

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9b4f4d0c8328a069e959ba476bea