### PR TITLE
Remove floating new-chat button and refine send icon

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -115,14 +115,6 @@ export default function ChatPage() {
         {activeConv && (
           <ChatWindow chatId={activeConv.id} user={activeConv.user} onBack={() => setActive(null)} />
         )}
-        {loggedIn && (
-          <button
-            className="fixed bottom-4 right-4 bg-brand text-white w-12 h-12 rounded-full shadow-lg"
-            aria-label="New Message"
-          >
-            +
-          </button>
-        )}
       </div>
     </div>
   );

--- a/src/app/components/chat/ChatWindow.tsx
+++ b/src/app/components/chat/ChatWindow.tsx
@@ -137,9 +137,9 @@ export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
           <button
             onClick={handleSend}
             aria-label="Send message"
-            className="bg-brand text-white p-2 rounded-full ml-2"
+            className="bg-brand text-white p-3 rounded-full ml-2 shadow-md hover:opacity-90"
           >
-            <PaperAirplaneIcon className="w-5 h-5 rotate-90" />
+            <PaperAirplaneIcon className="w-6 h-6 -rotate-45" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- drop the unused "new message" button on the Chat page
- enhance the send button with a larger, angled icon

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba61e40c483289b52c18c33699371