### PR TITLE
Fix profile feed spacing

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -230,7 +230,7 @@ export default function PublicProfilePage() {
                             Энэ хэрэглэгч нийтлэлгүй байна.
                         </p>
                     )}
-                    <div className="space-y-4">
+                    <div className="flex flex-col gap-4">
                         {userPosts.map((post) => (
                             <HomeFeedPost
                                 key={post._id}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -266,7 +266,7 @@ export default function MyOwnProfilePage() {
                             ))}
                         </div>
                     ) : userPosts.length > 0 ? (
-                        <div className="space-y-4">
+                        <div className="flex flex-col gap-4">
                             {userPosts.map((post) => (
                                 <HomeFeedPost
                                     key={post._id}


### PR DESCRIPTION
## Summary
- keep spacing consistent by adding gap between posts on profile pages
- adjust both personal and public profile feeds

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baf71117c83289ef3d026bb9953b7