### PR TITLE
Improve LoginRequiredPopup UX

### DIFF
--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { AuthProvider, useAuth } from "../context/AuthContext";
 import { CartProvider } from "../context/CartContext";
@@ -22,7 +22,6 @@ import SidebarControl from "./SidebarControl";
 import NavigationLoader from "./NavigationLoader";
 import LoadingOverlay from "./LoadingOverlay";
 import LoginRequiredPopup from "./LoginRequiredPopup";
-import PageSkeleton from "./PageSkeleton";
 import Link from "next/link";
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
@@ -31,23 +30,29 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
   const { loggedIn, loading } = useAuth();
   const publicPaths = ["/login", "/register"];
   const [showPrompt, setShowPrompt] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (!loading && !loggedIn && !publicPaths.some((p) => pathname.startsWith(p))) {
       setShowPrompt(true);
-      const timer = setTimeout(() => router.push("/login"), 1500);
-      return () => clearTimeout(timer);
+      timerRef.current = setTimeout(() => router.push("/login"), 1500);
+      return () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+      };
     }
   }, [loading, loggedIn, pathname, router]);
+
+  const handleClosePrompt = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setShowPrompt(false);
+    router.push("/login");
+  };
 
   return (
     <>
       {children}
       {showPrompt && (
-        <>
-          <PageSkeleton />
-          <LoginRequiredPopup />
-        </>
+        <LoginRequiredPopup onClose={handleClosePrompt} />
       )}
     </>
   );

--- a/src/app/components/LoginRequiredPopup.tsx
+++ b/src/app/components/LoginRequiredPopup.tsx
@@ -1,20 +1,22 @@
 "use client";
 import { motion } from "framer-motion";
 
-export default function LoginRequiredPopup() {
+export default function LoginRequiredPopup({ onClose }: { onClose: () => void }) {
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-md"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
+      onClick={onClose}
     >
       <motion.div
         initial={{ scale: 0.95, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
-        className="bg-[#111] text-white px-6 py-4 rounded-xl shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        className="bg-[#212121] text-white px-6 py-4 rounded-lg shadow-lg border border-brand max-w-xs w-full text-center"
       >
-        <p className="text-lg font-medium">Чи эхлээд нэвтрэх хэрэгтэй</p>
+        <p className="text-base font-medium">Чи эхлээд нэвтрэх хэрэгтэй</p>
       </motion.div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- simplify `LoginRequiredPopup` style and allow dismissing by click
- show login popup without skeleton overlay and handle closing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb7bc5e508328a1371c981c39b13e