### PR TITLE
Fix mobile header logo and add feed padding

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -37,7 +37,11 @@ export default function Header() {
             >
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
-                    <Link href="/" className="flex items-center" aria-label="Home">
+                    <Link
+                        href="/"
+                        className="hidden md:flex items-center"
+                        aria-label="Home"
+                    >
                         <Image
                             src="/logo.png"
                             alt="Vone logo"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -328,7 +328,7 @@ export default function HomePage() {
 
 
         {/* Main content */}
-        <main>
+        <main className="pb-24 md:pb-0">
           {/* Prompt login */}
           {!loggedIn && (
             <div className="bg-secondary p-6 text-center space-y-3">


### PR DESCRIPTION
## Summary
- hide logo in header on mobile screens
- add bottom padding for feed page so bottom nav doesn't cover content

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbbce7a848328b23f42a28a85a1f4