### PR TITLE
Remove right sidebar from chat page

### DIFF
--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -88,6 +88,7 @@ export default function LayoutClient({
   const pathname = usePathname();
   const isWidePage =
       pathname.startsWith("/dashboard") || pathname.startsWith("/classroom");
+  const isChatPage = pathname.startsWith("/chat");
 
   useEffect(() => {
     const timer = setTimeout(() => setMountLoading(false), 500);
@@ -147,14 +148,16 @@ export default function LayoutClient({
                       </nav>
                     </aside>
                     <div
-                        className={`w-full ${isWidePage ? "md:w-full" : "md:w-1/2 md:border-r md:border-supportBorder"}`}
+                        className={`w-full ${isWidePage ? "md:w-full" : isChatPage ? "md:w-3/4" : "md:w-1/2 md:border-r md:border-supportBorder"}`}
                     >
                       <div className="space-y-6">{children}</div>
                     </div>
-                    <aside
-                        id="right-sidebar"
-                        className="hidden md:block w-full md:w-1/4 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
-                    ></aside>
+                    {!isChatPage && (
+                        <aside
+                            id="right-sidebar"
+                            className="hidden md:block w-full md:w-1/4 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
+                        ></aside>
+                    )}
                   </main>
                 </div>
                 <BottomNav />

--- a/src/app/components/SidebarControl.tsx
+++ b/src/app/components/SidebarControl.tsx
@@ -20,6 +20,9 @@ export default function SidebarControl() {
       left.style.display = '';
       right.style.display = '';
     }
+    if (pathname.startsWith('/chat')) {
+      right.style.display = 'none';
+    }
   }, [pathname]);
   return null;
 }


### PR DESCRIPTION
## Summary
- hide the right sidebar when visiting `/chat`
- widen chat page main content to fill space when the sidebar is hidden
- update SidebarControl logic to keep the right sidebar hidden on `/chat`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce842bef88328b6d830e3b8ee31ae