### PR TITLE
Enhance auth pages UI

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -57,11 +57,11 @@ export default function LoginPage() {
     };
 
     return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand via-[#0e8386] to-backgroundDark text-white px-4 py-8">
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand via-blue-500 to-purple-600 text-white px-4 py-8">
             <motion.div
                 whileHover={{ opacity: 0.97 }}
                 transition={{ duration: 0.1, ease: "easeOut" }}
-                className="w-full max-w-md space-y-6 bg-[#111111] text-black dark:bg-[#111111] dark:text-white p-8 rounded-xl shadow-lg"
+                className="w-full max-w-md space-y-6 bg-backgroundDark/80 backdrop-blur text-white p-8 rounded-2xl shadow-2xl"
             >
                 <div className="text-center mb-4">
                     <h2 className="text-2xl font-bold">Монгол сошиал платформ</h2>
@@ -74,7 +74,7 @@ export default function LoginPage() {
                         </label>
                         <input
                             type="text"
-                            className="w-full border border-gray-300 rounded-lg px-4 py-3 text-black bg-[#111111] focus:bg-[#323232] focus:outline-none focus:ring-2 focus:ring-[#30c9e8] placeholder-gray-400"
+                            className="w-full border border-gray-700 rounded-lg px-4 py-3 bg-inputBg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand"
                             placeholder="Хэрэглэгчийн нэр"
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
@@ -87,7 +87,7 @@ export default function LoginPage() {
                         </label>
                         <input
                             type="password"
-                            className="w-full border border-gray-300 rounded-lg px-4 py-3 text-black bg-[#111111] focus:bg-[#323232] focus:outline-none focus:ring-2 focus:ring-[#30c9e8] placeholder-gray-400"
+                            className="w-full border border-gray-700 rounded-lg px-4 py-3 bg-inputBg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand"
                             placeholder="Нууц үг"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
@@ -115,7 +115,7 @@ export default function LoginPage() {
                     {error && <p className="text-red-600 text-sm" role="alert">{error}</p>}
                     <button
                         type="submit"
-                        className="w-full bg-[#30c9e8] text-white py-3 rounded-lg font-semibold hover:bg-[#28b6d3] active:bg-[#239bb3] transition-colors"
+                        className="w-full bg-brand text-white py-3 rounded-lg font-semibold hover:opacity-90 transition"
                     >
                         Нэвтрэх
                     </button>
@@ -127,7 +127,7 @@ export default function LoginPage() {
                 </div>
                 <button
                     onClick={() => router.push("/register")}
-                    className="block w-full text-sm font-medium text-brand underline hover:text-[#28b6d3]"
+                    className="block w-full text-sm font-medium text-brand underline hover:opacity-90"
                 >
                     Шинээр бүртгүүлэх
                 </button>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -230,16 +230,16 @@ export default function RegisterMultiStepPage() {
 
     // ---------- Utility: conditional className for inputs/selects ----------
     const getInputClass = (fieldName: string) => {
-        return `w-full rounded-md px-3 py-2 text-black bg-[#111111] focus:bg-[#323232] focus:outline-none focus:ring-2 ${
+        return `w-full rounded-md px-3 py-2 bg-inputBg text-white focus:outline-none focus:ring-2 ${
             fieldErrors[fieldName]
                 ? "border border-red-500 focus:ring-red-500"
-                : "border border-gray-300 focus:ring-brand"
+                : "border border-gray-700 focus:ring-brand"
         }`;
     };
 
     return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand via-[#0e8386] to-backgroundDark text-white px-4 py-8">
-            <div className="w-full max-w-md space-y-6 bg-[#111111] text-black dark:bg-[#111111] dark:text-white p-8 rounded-xl shadow-lg">
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand via-blue-500 to-purple-600 text-white px-4 py-8">
+            <div className="w-full max-w-md space-y-6 bg-backgroundDark/80 backdrop-blur text-white p-8 rounded-2xl shadow-2xl">
                 {error && <p className="text-red-600">{error}</p>}
                 {success && <p className="text-green-600">{success}</p>}
 
@@ -444,6 +444,13 @@ export default function RegisterMultiStepPage() {
                         </div>
                     </form>
                 )}
+                <button
+                    type="button"
+                    onClick={() => router.push("/login")}
+                    className="block w-full text-sm font-medium text-brand underline hover:opacity-90"
+                >
+                    Буцах
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- refresh login page look with gradient background and dark card
- style input fields with brand colors
- overhaul register page theme to match login
- add navigation button from register to login

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cee4a734c832895974e7853f4e1f3