### PR TITLE
Translate login prompt on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -330,15 +330,15 @@ export default function HomePage() {
           {/* Prompt login */}
           {!loggedIn && (
             <div className="bg-secondary p-6 text-center space-y-3">
-              <p>Feed үзэхийн тулд нэвтрэх эсвэл бүртгүүлэх шаардлагатай.</p>
+              <p>You need to log in or register to view the feed.</p>
               <Link href="/login" className="text-blue-600 underline">
-                Нэвтрэх
+                Log in
               </Link>
               <Link
                 href="/register"
                 className="block bg-brand text-white px-3 py-1 rounded w-fit mx-auto"
               >
-                Бүртгүүлэх
+                Register
               </Link>
             </div>
           )}


### PR DESCRIPTION
## Summary
- translate Mongolian login prompt text on the homepage to English

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726b7c1154832892ae1ece0daad422