### PR TITLE
Add invitation-based registration system

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ const cartRoutes    = require("./routes/cartRoutes"); // ← feature branch win
 const notificationRoutes = require("./routes/notification");
 const pushRoutes    = require("./routes/push");
 const lessonRoutes  = require("./routes/lessonRoutes");
+const inviteRoutes  = require("./routes/invite");
 const webpush       = require("web-push");
 const chatRoutesFn  = require("./routes/chat");
 
@@ -87,6 +88,7 @@ app.use("/api/products", productRoutes);
 app.use("/api/cart",     cartRoutes); // ← now live
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/push",     pushRoutes);
+app.use("/api/invite",   inviteRoutes);
 const chatRoutes = chatRoutesFn(io);
 app.use("/api/chat",    chatRoutes);
 app.use("/api/lessons", lessonRoutes);

--- a/server/models/Invite.js
+++ b/server/models/Invite.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const InviteSchema = new mongoose.Schema({
+  code: { type: String, required: true, unique: true },
+  inviter: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  used: { type: Boolean, default: false },
+  createdAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Invite', InviteSchema);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -9,6 +9,7 @@ const fs = require("fs");
 
 const User = require("../models/User");
 const authenticateToken = require("../middleware/authMiddleware");
+const Invite = require("../models/Invite");
 
 // ---------------------- FILE SIZE LIMITS (in bytes) ----------------------
 const MIN_FILE_SIZE = 10 * 1024;        // 10KB
@@ -67,7 +68,7 @@ router.post("/register", (req, res) => {
             console.log(req.files);
 
             // Destructure fields
-            const { username, password, phoneNumber, location, gender } = req.body;
+            const { username, password, phoneNumber, location, gender, inviteCode } = req.body;
 
             // Parse birthday
             let birthday = {};
@@ -98,14 +99,23 @@ router.post("/register", (req, res) => {
                 !gender ||
                 !birthday.year ||
                 !birthday.month ||
-                !birthday.day
+                !birthday.day ||
+                !inviteCode
             ) {
                 if (uploadedProfile) removeUploadedFile(uploadedProfile);
                 if (uploadedCover) removeUploadedFile(uploadedCover);
                 return res.status(400).json({
                     error:
-                        "Missing required fields (username, password, phoneNumber, location, gender, birthday)",
+                        "Missing required fields (username, password, phoneNumber, location, gender, birthday, inviteCode)",
                 });
+            }
+
+            // Validate invite code
+            const invite = await Invite.findOne({ code: inviteCode, used: false });
+            if (!invite) {
+                if (uploadedProfile) removeUploadedFile(uploadedProfile);
+                if (uploadedCover) removeUploadedFile(uploadedCover);
+                return res.status(400).json({ error: "Invalid invitation code" });
             }
 
             // Check if username is taken
@@ -130,6 +140,10 @@ router.post("/register", (req, res) => {
                 profilePicture: profilePicturePath,
                 coverImage: coverImagePath,
             });
+
+            // mark invite as used
+            invite.used = true;
+            await invite.save();
 
             // Success!
             return res.status(201).json({

--- a/server/routes/invite.js
+++ b/server/routes/invite.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+const crypto = require('crypto');
+const Invite = require('../models/Invite');
+const authenticateToken = require('../middleware/authMiddleware');
+
+// Create an invitation link
+router.post('/', authenticateToken, async (req, res) => {
+  try {
+    const code = crypto.randomBytes(16).toString('hex');
+    const invite = await Invite.create({ code, inviter: req.user._id });
+    res.json({ code });
+  } catch (err) {
+    console.error('Create invite error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Validate an invitation code (optional endpoint)
+router.get('/:code', async (req, res) => {
+  try {
+    const invite = await Invite.findOne({ code: req.params.code, used: false });
+    if (!invite) return res.status(404).json({ valid: false });
+    res.json({ valid: true });
+  } catch (err) {
+    console.error('Validate invite error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useState } from "react";
+import { useAuth } from "@/app/context/AuthContext";
+import { BASE_URL } from "../lib/config";
+
+export default function InvitePage() {
+  const { user } = useAuth();
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+
+  const createInvite = async () => {
+    if (!user?.accessToken) {
+      setError("Нэвтрэх шаардлагатай");
+      return;
+    }
+    try {
+      const res = await fetch(`${BASE_URL}/api/invite`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${user.accessToken}` },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Алдаа");
+      setCode(`${window.location.origin}/register?invite=${data.code}`);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-4 p-4">
+      <button
+        onClick={createInvite}
+        className="px-4 py-2 bg-brand text-white rounded"
+      >
+        Урилга үүсгэх
+      </button>
+      {code && (
+        <div className="text-center break-all">
+          <p>Дараах холбоосыг хуваалцаарай:</p>
+          <p className="text-sm text-blue-500">{code}</p>
+        </div>
+      )}
+      {error && <p className="text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import axios from "axios";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { BASE_URL } from "../lib/config";
 
 /** Helper validations **/
@@ -20,6 +20,8 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024;  // 5MB
 
 export default function RegisterMultiStepPage() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const initialInvite = searchParams.get("invite") || "";
 
     // ---------- STEP CONTROL ----------
     const [step, setStep] = useState(1);
@@ -30,6 +32,7 @@ export default function RegisterMultiStepPage() {
     const [birthMonth, setBirthMonth] = useState("");
     const [birthDay, setBirthDay] = useState("");
     const [birthYear, setBirthYear] = useState("");
+    const [inviteCode, setInviteCode] = useState(initialInvite);
 
     // ---------- STEP 2 FIELDS ----------
     const [password, setPassword] = useState("");
@@ -54,6 +57,7 @@ export default function RegisterMultiStepPage() {
         gender: "",
         location: "",
         profilePicture: "",
+        inviteCode: "",
     });
 
     // Replace with your actual server endpoint
@@ -74,6 +78,7 @@ export default function RegisterMultiStepPage() {
             gender: "",
             location: "",
             profilePicture: "",
+            inviteCode: "",
         });
 
         const errors: { [key: string]: string } = {};
@@ -120,6 +125,7 @@ export default function RegisterMultiStepPage() {
             gender: "",
             location: "",
             profilePicture: "",
+            inviteCode: "",
         });
 
         const errors: { [key: string]: string } = {};
@@ -135,6 +141,9 @@ export default function RegisterMultiStepPage() {
         }
         if (!profilePicture) {
             errors.profilePicture = "Профайл зураг оруулна уу.";
+        }
+        if (!inviteCode.trim()) {
+            errors.inviteCode = "Урилгын код шаардлагатай";
         }
 
         if (Object.keys(errors).length > 0) {
@@ -164,6 +173,9 @@ export default function RegisterMultiStepPage() {
             formData.append("location", location);
             if (profilePicture) {
                 formData.append("profilePicture", profilePicture);
+            }
+            if (inviteCode) {
+                formData.append("inviteCode", inviteCode);
             }
 
             const res = await axios.post(`${BASE_URL}/api/auth/register`, formData, {
@@ -290,8 +302,23 @@ export default function RegisterMultiStepPage() {
                                 value={phoneNumber}
                                 onChange={(e) => setPhoneNumber(e.target.value)}
                             />
-                            {fieldErrors.phoneNumber && (
+                        {fieldErrors.phoneNumber && (
                                 <p className="text-red-500 text-sm mt-1">{fieldErrors.phoneNumber}</p>
+                            )}
+                        </div>
+
+                        {/* INVITE CODE */}
+                        <div>
+                            <label className="block font-medium text-black mb-1">Урилгын код</label>
+                            <input
+                                type="text"
+                                className={getInputClass("inviteCode")}
+                                placeholder="Invite code"
+                                value={inviteCode}
+                                onChange={(e) => setInviteCode(e.target.value)}
+                            />
+                            {fieldErrors.inviteCode && (
+                                <p className="text-red-500 text-sm mt-1">{fieldErrors.inviteCode}</p>
                             )}
                         </div>
 


### PR DESCRIPTION
## Summary
- implement `Invite` model and routes
- require invitation code for user registration
- expose `/api/invite` endpoint
- mount new route and add invite generator page
- update register form to accept invite code

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740fd7b3d48328a56c13cb719f8ebc