### PR TITLE
Switch site palette to black and white

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,37 +66,49 @@ body {
     font-family: "Poppins", sans-serif;
 }
 
+body {
+    background-color: #FFFFFF;
+    color: #000000;
+}
+
 html {
-    background-color: #F5F6F8;
+    background-color: #FFFFFF;
+    color: #000000;
     color-scheme: light;
-    --brand-color: #119C99;
-    --support-border: #272F36;
-    --background-dark: #111111;
-    --text-primary: #272F36;
-    --accent: #FF2C55;
-    --premium: #119C99;
-    --link: #44B2DF;
+    --brand-color: #000000;
+    --support-border: #000000;
+    --background-dark: #000000;
+    --text-primary: #000000;
+    --accent: #000000;
+    --premium: #000000;
+    --link: #000000;
 }
 
 html.dark {
-    background-color: #111111;
+    background-color: #000000;
     color-scheme: dark;
-    color: #F5F6F8;
-    --support-border: #272F36;
+    color: #FFFFFF;
+    --support-border: #FFFFFF;
+    --brand-color: #FFFFFF;
+    --background-dark: #000000;
+    --text-primary: #FFFFFF;
+    --accent: #FFFFFF;
+    --premium: #FFFFFF;
+    --link: #FFFFFF;
 }
 
 html.dark body {
-    background-color: #111111;
-    color: #F5F6F8;
+    background-color: #000000;
+    color: #FFFFFF;
 }
 
 
 html.dark .bg-white {
-    background-color: #111111 !important;
+    background-color: #000000 !important;
 }
 
 html.dark .text-black {
-    color: #ffffff !important;
+    color: #FFFFFF !important;
 }
 
 html.dark .text-gray-700,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,18 +8,18 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        brand: '#119C99',
-        backgroundDark: '#111111',
-        surface: '#F5F6F8',
-        textPrimary: '#272F36',
-        accent: '#FF2C55',
-        premium: '#119C99',
-        link: '#44B2DF',
-        supportBorder: '#272F36',
-        primary: '#111111',
-        secondary: '#111111',
-        inputBg: '#1E1E1E',
-        inputText: '#AFAFAF',
+        brand: '#000000',
+        backgroundDark: '#000000',
+        surface: '#FFFFFF',
+        textPrimary: '#000000',
+        accent: '#000000',
+        premium: '#000000',
+        link: '#000000',
+        supportBorder: '#000000',
+        primary: '#000000',
+        secondary: '#000000',
+        inputBg: '#FFFFFF',
+        inputText: '#000000',
       },
       fontFamily: {
         sans: ['Inter', 'Helvetica', 'Arial', 'sans-serif'], // Minimalistic and clean font stack


### PR DESCRIPTION
## Summary
- override Tailwind colors so only black and white variants are used
- update global CSS variables and base styles to use pure black/white

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f880d0748328b2956375c14c78eb