### PR TITLE
Update brand color scheme and add Antaqor page

### DIFF
--- a/docs/classroom-design.md
+++ b/docs/classroom-design.md
@@ -10,7 +10,7 @@ This document describes the UX/UI specifications for the `Classroom` page. The g
 - **Layering**: Both the toggle button and sidebar use a z-index above the header (`z-[1000]`) so they remain clickable on small screens.
 
 ## Colors
-- **Brand color**: `#119C99` (`bg-brand` in Tailwind config).
+- **Brand color**: `#1400FF` (`bg-brand` in Tailwind config).
 - **Sidebar borders**: `border-gray-200` on light mode.
 - **Completed state**: green `#22c55e` icons (`text-green-500`) and progress bar (`bg-green-400`).
 - **Selected item**: `bg-cyan-50` background with a left border `border-cyan-400`.

--- a/docs/notifications-design.md
+++ b/docs/notifications-design.md
@@ -22,7 +22,7 @@ This document outlines the UX and UI principles for the notifications page. The 
 
 ## Colors
 
-- The brand color `#119C99` is used for the unread dot and link accents.
+- The brand color `#1400FF` is used for the unread dot and link accents.
 - Background color follows existing theme classes (`bg-[#111111]` etc.).
 
 ## Interaction

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,7 @@ const nextConfig: NextConfig = {
             'dsifg2gm0y83d.cloudfront.net',
             'www.vone.mn',
             'vone.mn',
+            'sdmntprwestus3.oaiusercontent.com',
         ],
     },
 };

--- a/src/app/antaqor/page.tsx
+++ b/src/app/antaqor/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import Image from "next/image";
+
+export default function AntaqorPage() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-black">
+      <Image
+        src="https://sdmntprwestus3.oaiusercontent.com/files/00000000-d4c8-61fd-967a-ac9b3e52987d/raw?se=2025-07-30T03%3A26%3A51Z&sp=r&sv=2024-08-04&sr=b&scid=49752a5f-a005-5901-863c-00e04675bffd&skoid=b64a43d9-3512-45c2-98b4-dea55d094240&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-07-29T18%3A53%3A16Z&ske=2025-07-30T18%3A53%3A16Z&sks=b&skv=2024-08-04&sig=Rd1bfB2JXS9rox7p%2Blfi6Fk9A7w7Ard%2B1WsP2sqOnjc%3D"
+        alt="Antaqor"
+        width={800}
+        height={600}
+        className="object-contain"
+        priority
+      />
+    </div>
+  );
+}

--- a/src/app/components/chat/ChatWindow.tsx
+++ b/src/app/components/chat/ChatWindow.tsx
@@ -99,8 +99,8 @@ export default function ChatWindow({ chatId, user, onBack }: ChatWindowProps) {
                 <div
                   className={`px-3 py-2 rounded-2xl text-sm shadow-[0_1px_1px_rgba(0,0,0,0.15)] ${
                     isMe
-                      ? "bg-[#119C99] text-white rounded-br-none"
-                      : "bg-[#CD4178] text-black rounded-bl-none"
+                      ? "bg-brand text-white rounded-br-none"
+                      : "bg-black text-white rounded-bl-none"
                   }`}
                 >
                   {msg.text}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,14 +28,14 @@
 @keyframes neon-glow {
     0%, 100% {
         text-shadow:
-                0 0 8px #119C99,
-                0 0 16px #FFC0CB,
-                0 0 32px #119C99;
+                0 0 8px #1400FF,
+                0 0 16px #1400FF,
+                0 0 32px #1400FF;
     }
     50% {
         text-shadow:
-                0 0 24px #FFC0CB,
-                0 0 40px #119C99;
+                0 0 24px #1400FF,
+                0 0 40px #1400FF;
     }
 }
 
@@ -67,34 +67,34 @@ body {
 }
 
 body {
-    background-color: #FFFFFF;
-    color: #000000;
+    background-color: #000000;
+    color: #FFFFFF;
 }
 
 html {
-    background-color: #FFFFFF;
-    color: #000000;
-    color-scheme: light;
-    --brand-color: #000000;
-    --support-border: #000000;
+    background-color: #000000;
+    color: #FFFFFF;
+    color-scheme: dark;
+    --brand-color: #1400FF;
+    --support-border: #1400FF;
     --background-dark: #000000;
-    --text-primary: #000000;
-    --accent: #000000;
-    --premium: #000000;
-    --link: #000000;
+    --text-primary: #FFFFFF;
+    --accent: #1400FF;
+    --premium: #1400FF;
+    --link: #1400FF;
 }
 
 html.dark {
     background-color: #000000;
     color-scheme: dark;
     color: #FFFFFF;
-    --support-border: #FFFFFF;
-    --brand-color: #FFFFFF;
+    --support-border: #1400FF;
+    --brand-color: #1400FF;
     --background-dark: #000000;
     --text-primary: #FFFFFF;
-    --accent: #FFFFFF;
-    --premium: #FFFFFF;
-    --link: #FFFFFF;
+    --accent: #1400FF;
+    --premium: #1400FF;
+    --link: #1400FF;
 }
 
 html.dark body {

--- a/src/app/img/heartpostactive.svg
+++ b/src/app/img/heartpostactive.svg
@@ -3,7 +3,7 @@
         viewBox="0 0 24 24"
         width="24"
         height="24"
-        fill="#119C99"
+        fill="#1400FF"
         stroke="none"
 >
     <!-- outer frame -->

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -80,7 +80,7 @@ export default function LoginPage() {
             >
                 <div className="text-center mb-4">
                     <h2
-                        className="text-3xl font-orbitron font-extrabold bg-gradient-to-r from-[#119C99] via-[#FFC0CB] to-[#119C99] bg-clip-text text-transparent tracking-widest uppercase neon-animate"
+                        className="text-3xl font-orbitron font-extrabold bg-gradient-to-r from-brand via-brand to-brand bg-clip-text text-transparent tracking-widest uppercase neon-animate"
                     >
                       Vone Network
                     </h2>
@@ -133,7 +133,7 @@ export default function LoginPage() {
                     {error && <p className="text-red-600 text-sm">{error}</p>}
                     <button
                         type="submit"
-                        className={`w-full py-3  rounded-md font-bold text-lg bg-[#119C99] hover:opacity-90 transition flex items-center justify-center gap-2 ${
+                        className={`w-full py-3  rounded-md font-bold text-lg bg-brand hover:opacity-90 transition flex items-center justify-center gap-2 ${
                             loading ? "opacity-50 cursor-not-allowed" : ""
                         }`}
                         disabled={loading}
@@ -148,7 +148,7 @@ export default function LoginPage() {
                 </div>
                 <button
                     onClick={() => router.push("/register")}
-                    className="block w-full text-sm font-medium text-brand hover:text-[#28b6d3]"
+                    className="block w-full text-sm font-medium text-brand hover:text-brand"
                 >
                     Register
                 </button>

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -119,7 +119,7 @@ export default function SubscriptionPage() {
               <p>
                 Гүйлгээний утга: <strong>{user?.username}</strong>
               </p>
-              <p className="text-[#CD4178]">
+              <p className="text-brand">
                 Үлдсэн хугацаа: {Math.floor(countdown / 60)}:
                 {(countdown % 60).toString().padStart(2, "0")}
               </p>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -125,7 +125,7 @@ export default function UsersPage() {
                         <motion.div
                             key={user._id}
                             onClick={() => router.push(`/profile/${user._id}`)}
-                            className="bg-[#111111] border border-gray-700 rounded-lg p-4 flex flex-col items-center shadow transition-transform duration-300 hover:bg-[#323232] hover:shadow-lg hover:-translate-y-1 hover:ring-1 hover:ring-[#30c9e8] cursor-pointer"
+                            className="bg-[#111111] border border-gray-700 rounded-lg p-4 flex flex-col items-center shadow transition-transform duration-300 hover:bg-[#323232] hover:shadow-lg hover:-translate-y-1 hover:ring-1 hover:ring-brand cursor-pointer"
                         >
                             <div className="relative mb-3">
                                 {user.profilePicture ? (
@@ -134,10 +134,10 @@ export default function UsersPage() {
                                         alt={user.username}
                                         width={96}
                                         height={96}
-                                        className="w-24 h-24 rounded-full object-cover ring-2 ring-[#30c9e8]"
+                                        className="w-24 h-24 rounded-full object-cover ring-2 ring-brand"
                                     />
                                 ) : (
-                                    <div className="w-24 h-24 rounded-full bg-gray-200 ring-2 ring-[#30c9e8]" />
+                                    <div className="w-24 h-24 rounded-full bg-gray-200 ring-2 ring-brand" />
                                 )}
                                 <span className={`absolute bottom-1 right-1 w-3 h-3 rounded-full border border-gray-700 ${statusColors[status]}`} />
                             </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,18 +8,18 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        brand: '#000000',
+        brand: '#1400FF',
         backgroundDark: '#000000',
-        surface: '#FFFFFF',
-        textPrimary: '#000000',
-        accent: '#000000',
-        premium: '#000000',
-        link: '#000000',
-        supportBorder: '#000000',
-        primary: '#000000',
+        surface: '#000000',
+        textPrimary: '#FFFFFF',
+        accent: '#1400FF',
+        premium: '#1400FF',
+        link: '#1400FF',
+        supportBorder: '#1400FF',
+        primary: '#1400FF',
         secondary: '#000000',
-        inputBg: '#FFFFFF',
-        inputText: '#000000',
+        inputBg: '#000000',
+        inputText: '#FFFFFF',
       },
       fontFamily: {
         sans: ['Inter', 'Helvetica', 'Arial', 'sans-serif'], // Minimalistic and clean font stack


### PR DESCRIPTION
## Summary
- apply new blue brand color #1400FF across tailwind config and global CSS
- adjust login, chat, subscription and user pages to use brand color
- remove teal/pink colors and update docs
- allow external image domain and add `/antaqor` page with provided image

## Testing
- `npx jest` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68898348ee888328973af320e64a6dc8